### PR TITLE
Add quick start notebook

### DIFF
--- a/examples/quick_start.ipynb
+++ b/examples/quick_start.ipynb
@@ -3,7 +3,50 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["# Quick Start\n", "Use this notebook to try prompts."]
+   "source": [
+    "# Quick Start: Evaluating TeslaMind Prompts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to run the evaluation script offline and inspect prompt files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\nprint('Available prompts:', os.listdir('../prompts'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python ../evaluation/run_eval.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\nprint(pathlib.Path('../evaluation/results.json').read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The evaluation script loads each prompt, runs a dummy language model, and stores results in `evaluation/results.json`."
+   ]
   }
  ],
  "metadata": {},


### PR DESCRIPTION
## Summary
- add a quick start notebook showing how to run the evaluation script offline

## Testing
- `python -m json.tool examples/quick_start.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68487d3384e483208800612ebe5dd9f5