### PR TITLE
Add stubs for advanced prompt features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 
 - [Objectives](#objectives)
 - [Guide to Using This Repository](#guide-to-using-this-repository)
+- [Advanced Features](#advanced-features)
 - [Example Task](#example-task)
 - [Detailed Prompt Breakdown](#detailed-prompt-breakdown)
   - [Prompt #1 (Ambitious Benchmark)](#prompt-1-ambitious-benchmark)
@@ -37,6 +38,22 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 1.  **Choose the Ideal Prompt:** Select a prompt that aligns perfectly with the complexity and creativity required for your task.
 2.  **Provide Detailed Instructions:** Equip the LLM with all necessary context and specifics to excel in the task at hand.
 3.  **Use the CLI:** After installation, run `teslamind list` to see available prompts and `teslamind show <name>` to view a prompt.
+
+### Advanced Features
+
+Beyond the core prompt library, TeslaMind ships with experimental modules for
+power users:
+
+- **Self-looping refinement** – iteratively polish prompts via a user-supplied
+  refinement function.
+- **Federated evaluation** – run prompt assessments across logical shards,
+  preserving an interface for future distributed backends.
+- **RLHF trainer** – apply reward signals from feedback providers to retain only
+  positively scored prompts.
+- **Clinical safety filter** – block configurable medical terms to avoid
+  generating sensitive clinical guidance.
+
+See the [advanced feature documentation](docs/advanced.md) for usage examples.
 
 ### Example Task
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,44 @@
+# Advanced Features
+
+TeslaMind includes experimental modules that demonstrate how the prompt
+library can be extended.
+
+## Self-looping refinement
+Use `SelfLoopingPromptGenerator` to iteratively refine prompts.
+
+```python
+from teslamind import SelfLoopingPromptGenerator
+
+def refine(p: str) -> tuple[str, bool]:
+    return p + " done", False
+
+SelfLoopingPromptGenerator(max_iters=3).generate("start", refine)
+```
+
+## Federated evaluation
+`run_federated_evaluation` evaluates prompts across logical shards.
+
+```python
+from teslamind import run_federated_evaluation
+run_federated_evaluation(["a", "bb"], len, shards=2)
+```
+
+## RLHF trainer
+`RLHFTrainer` keeps only prompts with positive reward.
+
+```python
+from teslamind import RLHFTrainer
+trainer = RLHFTrainer(lambda p, f: 1.0 if f == "good" else -1.0)
+trainer.train(["keep this", "drop that"], lambda p: "good")
+```
+
+## Clinical safety filter
+`filter_clinical_content` blocks configurable medical terms.
+
+```python
+from teslamind import filter_clinical_content
+filter_clinical_content("General guidance")
+```
+
+These modules are stubs intended for experimentation and can be expanded
+into full-featured implementations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,3 +2,7 @@
 
 TeslaMind is a lightweight toolkit and prompt collection inspired by Nikola Tesla's approach to innovation.
 Use it to explore personas, modes, and reusable prompt templates for your own LLM projects.
+
+For power users, TeslaMind also exposes [advanced features](advanced.md) such as
+self-looping refinement, federated evaluation, RLHF stubs, and a clinical safety
+filter.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,5 +8,6 @@ nav:
   - Modes: modes.md
   - Personas: personas.md
   - Scoring: score.md
+  - Advanced: advanced.md
   - API Reference: api.md
   - Contributing: contribute.md

--- a/teslamind/__init__.py
+++ b/teslamind/__init__.py
@@ -3,5 +3,17 @@
 from .version import __version__
 from .prompt import Prompt
 from .persona import Persona
+from .refinement import SelfLoopingPromptGenerator
+from .federated import run_federated_evaluation
+from .rlhf import RLHFTrainer
+from .safety import filter_clinical_content
 
-__all__ = ["Prompt", "Persona", "__version__"]
+__all__ = [
+    "Prompt",
+    "Persona",
+    "__version__",
+    "SelfLoopingPromptGenerator",
+    "run_federated_evaluation",
+    "RLHFTrainer",
+    "filter_clinical_content",
+]

--- a/teslamind/federated.py
+++ b/teslamind/federated.py
@@ -1,0 +1,30 @@
+"""Federated evaluation framework stubs."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, List
+
+
+def run_federated_evaluation(
+    prompts: Iterable[str], evaluate: Callable[[str], Any], shards: int = 1
+) -> List[Any]:
+    """Run evaluations across logical shards.
+
+    Parameters
+    ----------
+    prompts:
+        Iterable of prompt strings.
+    evaluate:
+        Function applied to each prompt.
+    shards:
+        Number of logical shards to split the work into. The function
+        currently executes sequentially but preserves the interface for
+        future distributed backends.
+    """
+    prompts = list(prompts)
+    if shards < 1:
+        raise ValueError("shards must be positive")
+    results: List[Any] = []
+    for prompt in prompts:
+        results.append(evaluate(prompt))
+    return results

--- a/teslamind/refinement.py
+++ b/teslamind/refinement.py
@@ -1,0 +1,28 @@
+"""Self-looping prompt refinement utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+
+class SelfLoopingPromptGenerator:
+    """Iteratively refines a prompt using a refinement function.
+
+    The refinement function receives the current prompt and returns a tuple
+    of the new prompt and a boolean indicating whether an improvement was
+    made. The generator stops when no improvement is reported or the
+    maximum number of iterations is reached.
+    """
+
+    def __init__(self, max_iters: int = 5) -> None:
+        self.max_iters = max_iters
+
+    def generate(
+        self, prompt: str, refine_func: Callable[[str], Tuple[str, bool]]
+    ) -> str:
+        """Run the self-looping refinement process."""
+        for _ in range(self.max_iters):
+            prompt, improved = refine_func(prompt)
+            if not improved:
+                break
+        return prompt

--- a/teslamind/rlhf.py
+++ b/teslamind/rlhf.py
@@ -1,0 +1,28 @@
+"""Reinforcement learning with human feedback stubs."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, List
+
+
+class RLHFTrainer:
+    """Simple RLHF training loop stub.
+
+    The trainer applies feedback to prompts and keeps those that
+    achieve a positive reward.
+    """
+
+    def __init__(self, reward_func: Callable[[str, str], float]):
+        self.reward_func = reward_func
+
+    def train(
+        self, prompts: Iterable[str], feedback_provider: Callable[[str], str]
+    ) -> List[str]:
+        """Return prompts with positive reward."""
+        trained: List[str] = []
+        for prompt in prompts:
+            feedback = feedback_provider(prompt)
+            reward = self.reward_func(prompt, feedback)
+            if reward > 0:
+                trained.append(prompt)
+        return trained

--- a/teslamind/safety.py
+++ b/teslamind/safety.py
@@ -1,0 +1,18 @@
+"""Clinical safety switch utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, Set
+
+DEFAULT_BLOCKED_TERMS: Set[str] = {"diagnosis", "treatment", "medical advice"}
+
+
+def filter_clinical_content(
+    text: str, blocked_terms: Iterable[str] = DEFAULT_BLOCKED_TERMS
+) -> str:
+    """Raise :class:`ValueError` if ``text`` contains any blocked term."""
+    lowered = text.lower()
+    for term in blocked_terms:
+        if term in lowered:
+            raise ValueError(f"Clinical term '{term}' detected")
+    return text

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -1,0 +1,44 @@
+import pytest
+
+from teslamind import (
+    SelfLoopingPromptGenerator,
+    run_federated_evaluation,
+    RLHFTrainer,
+    filter_clinical_content,
+)
+
+
+def test_self_looping_prompt_generator():
+    gen = SelfLoopingPromptGenerator(max_iters=3)
+
+    def refine(prompt: str):
+        if prompt.count("done") >= 3:
+            return prompt, False
+        return prompt + " done", True
+
+    result = gen.generate("start", refine)
+    assert result == "start done done done"
+
+
+def test_run_federated_evaluation():
+    prompts = ["a", "bb", "ccc"]
+    results = run_federated_evaluation(prompts, lambda p: len(p), shards=2)
+    assert results == [1, 2, 3]
+
+
+def test_rlhf_trainer():
+    def reward(prompt: str, feedback: str) -> float:
+        return 1.0 if feedback == "good" else -1.0
+
+    def feedback_provider(prompt: str) -> str:
+        return "good" if "keep" in prompt else "bad"
+
+    trainer = RLHFTrainer(reward_func=reward)
+    trained = trainer.train(["keep this", "drop that"], feedback_provider)
+    assert trained == ["keep this"]
+
+
+def test_filter_clinical_content():
+    with pytest.raises(ValueError):
+        filter_clinical_content("This is medical advice.")
+    assert filter_clinical_content("General guidance") == "General guidance"


### PR DESCRIPTION
## Summary
- add self-looping prompt refinement generator
- implement stubbed federated evaluation runner
- integrate RLHF training loop and clinical safety filter
- document the new experimental modules and provide usage examples in a dedicated guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89b6524388320b00ad208f04c45e2