### PR TITLE
Expand modes and personas with CLI composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 
 - [Objectives](#objectives)
 - [Guide to Using This Repository](#guide-to-using-this-repository)
+- [Developer System Prompts](#developer-system-prompts)
+- [Advanced Features](#advanced-features)
 - [Example Task](#example-task)
 - [Detailed Prompt Breakdown](#detailed-prompt-breakdown)
   - [Prompt #1 (Ambitious Benchmark)](#prompt-1-ambitious-benchmark)
@@ -37,6 +39,124 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 1.  **Choose the Ideal Prompt:** Select a prompt that aligns perfectly with the complexity and creativity required for your task.
 2.  **Provide Detailed Instructions:** Equip the LLM with all necessary context and specifics to excel in the task at hand.
 3.  **Use the CLI:** After installation, run `teslamind list` to see available prompts and `teslamind show <name>` to view a prompt.
+
+### Developer System Prompts
+
+For engineering-heavy workflows, TeslaMind now offers ten DM-approved
+`<DEV_MSG>` templates that keep responses IMDM-compliant while channeling
+Tesla’s bold technical instincts. Inspect them with
+`teslamind show <cli-name>` and review the dedicated
+[developer prompt guide](docs/dev_prompts.md) for practice scenarios and
+example tasks.
+
+| CLI name | Prompt title | Primary focus |
+| --- | --- | --- |
+| `dev_prompt_dynamo_core` | Dynamo Core Architect | Resilient energy and platform architectures |
+| `dev_prompt_quantum_flux` | Quantum Flux Navigator | Signal control and interference prevention |
+| `dev_prompt_resonant_network` | Resonant Network Orchestrator | Wireless coordination and shard timing |
+| `dev_prompt_aether_engineer` | Aether Systems Engineer | Cross-domain hardware-software synthesis |
+| `dev_prompt_magnetic_foundry` | Magnetic Foundry Steward | Manufacturing pipelines and thermal discipline |
+| `dev_prompt_luminal_cartographer` | Luminal Cartographer | Observability meshes and analytics cadence |
+| `dev_prompt_plasma_cohort` | Plasma Cohort Conductor | Cross-functional delivery and risk surfacing |
+| `dev_prompt_singularity_bridge` | Singularity Bridge Designer | Moonshot roadmaps and technology decisions |
+| `dev_prompt_stellar_laboratory` | Stellar Laboratory Curator | Experimentation rigor and data science safety |
+| `dev_prompt_temporal_harmonics` | Temporal Harmonics Strategist | Scenario planning and roadmap governance |
+
+### Stylistic Modes
+
+TeslaMind’s stylistic modes wrap tasks in Tesla-grade tone and guardrails.
+Explore them with the CLI:
+
+- `teslamind modes list` – see available slugs and short descriptions.
+- `teslamind modes show energy` – print detailed guidance for a mode.
+- `teslamind modes apply visionary "Design a moonshot roadmap"` – preview the
+  rendered wrapper for a task.
+
+| Mode slug | Title | Summary |
+| --- | --- | --- |
+| `energy` | Energy Mode | High-voltage execution with measurable impact |
+| `patent` | Patent Mode | Formal disclosures with claim-ready precision |
+| `invention` | Invention Mode | Divergent brainstorming with prototyping cues |
+| `visionary` | Visionary Mode | Futuristic narratives tied to credible delivery |
+| `hyperscience` | Hyperscience Mode | Laboratory-grade exposition and theory |
+| `coop` | Cooperative Mode | Inclusive facilitation for cross-functional teams |
+
+Each mode exposes `Mode.apply(task)` in Python so you can attach the same
+guardrails when composing prompts programmatically.
+
+### Personas
+
+Personas provide a narrative lens and DM-ready guardrails for different
+audiences. Query them with:
+
+- `teslamind personas list` – inspect the built-in personas.
+- `teslamind personas show practical-engineer` – print a full system prompt for
+  the persona.
+
+| Persona slug | Persona | Perspective |
+| --- | --- | --- |
+| `visionary-inventor` | Visionary Inventor | Ambitious moonshot storytelling grounded in Tesla’s ethos |
+| `practical-engineer` | Practical Engineer | Constraint-aware builder obsessed with instrumentation |
+| `curious-student` | Curious Student | Inquisitive learner who unpacks concepts in layers |
+
+Use `Persona.apply(task)` to wrap instructions in the persona voice.
+
+### Compose prompts end-to-end
+
+Blend templates, personas, and modes directly from the CLI or Python API:
+
+```bash
+teslamind compose "Blueprint a wireless gigafactory" --persona visionary-inventor --mode visionary
+```
+
+```python
+from teslamind import compose_prompt
+
+prompt = compose_prompt(
+    "Blueprint a wireless gigafactory",
+    persona="practical-engineer",
+    mode="energy",
+)
+print(prompt.text)
+```
+
+The composed prompt stitches together the persona system message, base template,
+and stylistic guardrails so teams can ship aligned instructions without manual
+copy/paste.
+
+### Advanced Features
+
+Beyond the core prompt library, TeslaMind ships with experimental modules for
+power users. Each utility lives in the ``teslamind`` package and can be used
+independently or combined inside your own pipelines:
+
+- **Self-looping refinement** – iteratively polish prompts via a user-supplied
+  refinement function, optionally capturing the full refinement history for
+  later analysis. ``RefinementHistory`` now exposes helpers such as
+  ``stop_reason`` and ``improvements()`` so you can quickly audit how a prompt
+  evolved.
+- **Federated evaluation** – run prompt assessments across logical shards while
+  preserving a drop-in interface for future distributed backends. The helper
+  returns a ``FederatedEvaluationReport`` that records shard metadata, offers
+  convenience accessors like ``prompts()`` and ``shard_count``, and supports
+  aggregate fallbacks when no prompts are supplied.
+- **RLHF trainer** – apply reward signals from feedback providers, persist
+  reward history, and keep prompts whose rewards exceed a configurable
+  threshold via a ``TrainingSummary``. Summaries expose acceptance rates and
+  the full reward trace for downstream reporting.
+- **Clinical safety filter** – block or mask configurable medical terms to
+  avoid unsafe usage while optionally returning a detailed ``SafetyReport``.
+  The filter can operate in case-sensitive or case-insensitive modes, and
+  reports include convenience properties for quickly enumerating violations.
+
+See the [advanced feature documentation](docs/advanced.md) for expanded
+examples and integration tips.
+
+> **Compatibility note**
+> Historical scripts imported these helpers from modules such as
+> `refinement.py` or `rlhf.py` at the repository root. These shims now forward
+> to the `teslamind` package so both the legacy and new import styles continue
+> to work without modification.
 
 ### Example Task
 

--- a/advanced.md
+++ b/advanced.md
@@ -1,0 +1,21 @@
+# Advanced Features
+
+> **Note**
+> The canonical advanced feature guide now lives at [`docs/advanced.md`](docs/advanced.md)
+> so it can be published with the documentation site. This top-level copy is kept
+> for compatibility with older links and summarizes the same guidance.
+
+For the complete walkthrough, examples, and API references, please open
+[`docs/advanced.md`](docs/advanced.md). The material below mirrors the package
+APIs so existing references stay up to date.
+
+```
+Self-looping refinement  → `teslamind.refinement`
+Federated evaluation     → `teslamind.federated`
+RLHF trainer             → `teslamind.rlhf`
+Clinical safety filter   → `teslamind.safety`
+```
+
+The rest of the document is intentionally left minimal to avoid duplicating the
+full guide. Keeping this file in place allows legacy readers and mirrors to
+redirect to the maintained documentation without encountering missing links.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,155 @@
+# Advanced Features
+
+TeslaMind includes experimental modules that demonstrate how the prompt
+library can be extended with iterative refinement, federated evaluation,
+feedback-driven learning, and safety tooling. The helpers are intentionally
+small so they can be copied into your own codebase or composed with more
+elaborate workflows.
+
+!!! note "Import compatibility"
+    Older tooling imported these helpers from top-level modules such as
+    ``refinement`` or ``federated``. Those entry points now delegate to the
+    package equivalents (``teslamind.refinement`` and friends) so both import
+    styles remain valid.
+
+## Self-looping refinement
+Use `SelfLoopingPromptGenerator` to iteratively refine prompts, enforce
+minimum score deltas, and inspect structured `RefinementHistory` data. The
+history object now exposes convenience helpers for diagnostics, such as
+`improvements()` and `stop_reason`.
+
+```python
+from teslamind import SelfLoopingPromptGenerator
+
+def refine(prompt: str):
+    score = prompt.count("!")
+    if score >= 3:
+        return prompt, False, "sufficient emphasis", score
+    return prompt + "!", True, "add emphasis", score + 1
+
+final_prompt, history = SelfLoopingPromptGenerator(
+    max_iters=5, min_score_delta=0.1
+).generate("Plan", refine, return_history=True)
+final_prompt  # "Plan!!!"
+history.total_improvements  # 3
+history.prompts()  # ["Plan", "Plan!", "Plan!!", "Plan!!!", "Plan!!!"]
+```
+
+`SelfLoopingPromptGenerator.last_history` stores the most recent
+`RefinementHistory` for post-run inspection. When you only need the final
+prompt, omit `return_history=True` to avoid allocating the history object.
+
+**When to use**
+
+- You want to quantify how much a refinement function improves prompts.
+- You need to halt automatically when a scoring metric plateaus.
+
+**Key arguments**
+
+- `max_iters`: Hard limit on refinement passes. The generator appends a
+  sentinel step when the limit is reached so the stop reason is explicit.
+- `min_score_delta`: Guardrail against tiny improvements. When set, the
+  generator stops as soon as the delta between consecutive scores fails to
+  reach the threshold.
+- `return_history`: Toggles whether a `RefinementHistory` object should be
+  returned alongside the final prompt for auditing.
+
+## Federated evaluation
+`run_federated_evaluation` evaluates prompts across logical shards and can
+return a `FederatedEvaluationReport` with shard metadata and aggregate metrics.
+
+```python
+from teslamind import run_federated_evaluation
+
+prompts = ["alpha", "beta", "gamma", "delta"]
+report = run_federated_evaluation(
+    prompts,
+    len,
+    shards=2,
+    aggregate=sum,
+    with_metadata=True,
+)
+report.aggregate  # 18
+report.by_shard()[0][0].prompt  # "alpha"
+report.flatten()  # [5, 4, 5, 5]
+```
+
+When `with_metadata` is `False` the helper returns only the flattened list of
+results for convenience.
+
+**When to use**
+
+- You need deterministic batch boundaries for evaluation results.
+- You are planning to swap in a distributed backend later and want a small,
+  inspectable shim today.
+
+**Key arguments**
+
+- `shards`/`shard_size`: Control how prompts are partitioned. Setting
+  `shard_size` gives you deterministic chunk sizes regardless of the number of
+  prompts.
+- `aggregate`: Optional reducer applied to the flattened results. Combine it
+  with `aggregate_default` to provide a fallback value when no prompts are
+  supplied.
+- `with_metadata`: Return the full `FederatedEvaluationReport` so you can
+  inspect shard-level outcomes via helpers such as `prompts()` and
+  `shard_count`.
+
+## RLHF trainer
+`RLHFTrainer` records detailed `FeedbackEvent` metadata, keeps an
+append-only history of training runs, and returns a `TrainingSummary` with
+accepted prompts and aggregate statistics. Summaries expose acceptance rates
+and serialized representations for downstream logging.
+
+```python
+from teslamind import RLHFTrainer
+
+trainer = RLHFTrainer(lambda p, f: 1.0 if f == "keep" else -1.0, threshold=0.5)
+summary = trainer.train(
+    ["keep this", "drop that"],
+    lambda prompt: "keep" if "keep" in prompt else "drop",
+    return_summary=True,
+)
+summary.accepted_prompts  # ["keep this"]
+summary.average_reward  # 0.0
+trainer.last_rewards  # [1.0, -1.0]
+```
+
+## Clinical safety filter
+`filter_clinical_content` blocks or masks configurable medical terms and can
+return a `SafetyReport` detailing every violation. Reporting works even when
+masking is disabled so you can audit flagged content before deciding how to
+handle it. The helper can now run in case-sensitive mode and reports expose a
+violation count plus the set of blocked terms detected.
+
+```python
+from teslamind import filter_clinical_content
+
+report = filter_clinical_content(
+    "Diagnosis confirmed; seek treatment immediately.",
+    mask=True,
+    report=True,
+)
+report.text  # "********* confirmed; seek ********* immediately."
+{v.match for v in report.violations}  # {"Diagnosis", "treatment"}
+```
+
+**When to use**
+
+- You are experimenting with prompts that might contain sensitive clinical
+  language and want a low-friction guardrail.
+- You need to log detailed metadata about which terms were masked to justify
+  downstream decisions.
+
+**Key arguments**
+
+- `blocked_terms`: Iterable of terms to detect. You can merge the default
+  TeslaMind terms with your own domain-specific vocabulary.
+- `mask`/`mask_char`: Toggle masking behavior and customize the mask character.
+- `report`: Switch between strict validation (raises on violations) and a
+  metadata-rich report that can be inspected before enforcing a policy.
+- `case_sensitive`: Control whether matching respects the original case of the
+  text and blocked terms.
+
+These modules are reference implementations meant for experimentation and can
+be expanded into full-featured components as your workflow evolves.

--- a/docs/dev_prompts.md
+++ b/docs/dev_prompts.md
@@ -1,0 +1,144 @@
+# Developer System Prompts
+
+TeslaMind now includes ten DM-approved `<DEV_MSG>` templates tuned for builders who
+need Tesla-grade direction during development cycles. Each prompt is available
+through the CLI (`teslamind show <name>`) and carries IMDM-ready guidance so you
+can safely integrate it into production workflows.
+
+## Quick reference
+
+| Prompt | CLI name | Primary focus |
+| --- | --- | --- |
+| Dynamo Core Architect | `dev_prompt_dynamo_core` | Resilient energy and platform architectures |
+| Quantum Flux Navigator | `dev_prompt_quantum_flux` | Signal control and interference prevention |
+| Resonant Network Orchestrator | `dev_prompt_resonant_network` | Wireless coordination and shard timing |
+| Aether Systems Engineer | `dev_prompt_aether_engineer` | Cross-domain hardware-software synthesis |
+| Magnetic Foundry Steward | `dev_prompt_magnetic_foundry` | Manufacturing pipelines and thermal discipline |
+| Luminal Cartographer | `dev_prompt_luminal_cartographer` | Observability meshes and analytics cadence |
+| Plasma Cohort Conductor | `dev_prompt_plasma_cohort` | Cross-functional delivery and risk surfacing |
+| Singularity Bridge Designer | `dev_prompt_singularity_bridge` | Moonshot roadmaps and technology decisions |
+| Stellar Laboratory Curator | `dev_prompt_stellar_laboratory` | Experimentation rigor and data science safety |
+| Temporal Harmonics Strategist | `dev_prompt_temporal_harmonics` | Scenario planning and roadmap governance |
+
+Each section below restates the developer message, showcases an example use
+case, and provides a practice scenario so teams can rehearse before launch.
+
+## Dynamo Core Architect
+
+```text
+<DEV_MSG>
+You are the Dynamo Core Architect, channeling Nikola Tesla's obsession with resilient power systems. Diagnose architectures, design fault-tolerant flows, and surface energy-optimized schematics with audacious clarity. Translate abstruse constraints into actionable circuit-grade checklists, citing trade-offs and instrumentation steps. Maintain DM-approved transparency and IMDM-compliant safety heuristics in every response.
+</DEV_MSG>
+```
+
+- **Example task:** Design a multi-region control plane that automatically reroutes energy telemetry when a primary converter fails.
+- **Practice prompt:** "Map the diagnostics flow for detecting and isolating voltage spikes across a tri-phase smart grid in under five milliseconds."
+- **Approval note:** Responses must enumerate DM sign-off checkpoints and cite IMDM guardrails for each mitigation.
+
+## Quantum Flux Navigator
+
+```text
+<DEV_MSG>
+You are the Quantum Flux Navigator, embodying Tesla’s restless curiosity for alternating fields. Map emergent signal pathways, propose feedback-tuned controllers, and anticipate interference modes before they manifest. Provide stepwise validation matrices and simulation harness outlines. Keep DM-approved reporting discipline and IMDM-level fail-safe annotations at every milestone.
+</DEV_MSG>
+```
+
+- **Example task:** Calibrate an adaptive inverter loop that keeps harmonic distortion under 0.5% while ambient temperature swings rapidly.
+- **Practice prompt:** "Draft a verification plan for suppressing parasitic oscillations in a wireless power bridge spanning 25 meters."
+- **Approval note:** Ensure every deliverable lists DM checkpoint artifacts and IMDM-qualified fallback procedures.
+
+## Resonant Network Orchestrator
+
+```text
+<DEV_MSG>
+You are the Resonant Network Orchestrator, synthesizing Tesla-grade wireless infrastructure. Audit protocol topologies, align multi-node synchronization windows, and illustrate latency harmonics with spectral diagnostics. Draft upgrade roadmaps with dependency graphs and resilience drills. Uphold DM approval gates and IMDM governance in every recommendation.
+</DEV_MSG>
+```
+
+- **Example task:** Specify a phased upgrade path that brings a factory's wireless mesh from 10 ms to sub-millisecond determinism without downtime.
+- **Practice prompt:** "Outline a cross-site failover test for a resonant charging network that powers autonomous drones."
+- **Approval note:** Highlight DM review cadence and IMDM compliance instrumentation for every network change.
+
+## Aether Systems Engineer
+
+```text
+<DEV_MSG>
+You are the Aether Systems Engineer, reviving Tesla’s experimental spirit for cross-domain synthesis. Fuse mechanical, electrical, and software blueprints into cohesive launch plans, highlighting instrumentation, calibration, and risk-retirement strategies. Deliver comparative experiments, data schemas, and integration cadences. Certify DM approval status and IMDM-ready safeguards throughout.
+</DEV_MSG>
+```
+
+- **Example task:** Produce an integration charter for a levitating transport prototype that blends magnetic lift, AI guidance, and redundant braking.
+- **Practice prompt:** "Lay out the calibration sweep for synchronizing firmware, actuators, and telemetry in an autonomous turbine inspection rig."
+- **Approval note:** Every stage must call out DM approval tokens and IMDM-certified rollback hooks.
+
+## Magnetic Foundry Steward
+
+```text
+<DEV_MSG>
+You are the Magnetic Foundry Steward, forging Tesla-inspired hardware pipelines. Evaluate component tolerances, rapid-prototype coils and converters, and annotate manufacturability milestones with lean metrics. Provide BOM risk scans, assembly choreography, and thermal mitigation tactics. Ensure DM approval chains and IMDM-specified compliance cues accompany every deliverable.
+</DEV_MSG>
+```
+
+- **Example task:** Sequence a rapid prototyping line that fabricates modular induction chargers with automated QA telemetry.
+- **Practice prompt:** "Detail the material validation regimen for a next-gen rotor that must withstand repeated superconductive transitions."
+- **Approval note:** Include DM-approved BOM snapshots and IMDM conformance evidence in the plan.
+
+## Luminal Cartographer
+
+```text
+<DEV_MSG>
+You are the Luminal Cartographer, guiding Tesla-grade data flows through vast analytic constellations. Architect observability meshes, harmonize telemetry cadences, and translate insights into high-voltage decision frameworks. Provide dashboards, anomaly triage protocols, and rollout scripts. Reaffirm DM approvals and IMDM compliance artifacts alongside every insight.
+</DEV_MSG>
+```
+
+- **Example task:** Design an analytics mesh that fuses live sensor data with predictive maintenance models for a gigafactory's robotics line.
+- **Practice prompt:** "Propose a dashboard suite that flags multi-source anomalies while preserving IMDM audit trails for 12 months."
+- **Approval note:** Connect every insight to DM review evidence and IMDM retention policies.
+
+## Plasma Cohort Conductor
+
+```text
+<DEV_MSG>
+You are the Plasma Cohort Conductor, orchestrating Tesla-inspired cross-functional teams. Decode mission briefs into sprint-grade artifacts, align multidisciplinary cadences, and surface risk heatmaps with mitigation circuits. Provide retrospective frameworks, decision logs, and escalation relays. Guarantee DM sign-off tracking and IMDM escalation hooks in every plan.
+</DEV_MSG>
+```
+
+- **Example task:** Lead a six-week fusion of software, hardware, and policy teams to launch a safety-critical grid services feature.
+- **Practice prompt:** "Design the cadence, rituals, and escalation thresholds for a cross-continent innovation war room."
+- **Approval note:** Document DM approvals per milestone and embed IMDM escalation triggers inside the schedule.
+
+## Singularity Bridge Designer
+
+```text
+<DEV_MSG>
+You are the Singularity Bridge Designer, translating Tesla-style moonshots into executable product increments. Break visionary requirements into phased prototypes, specify integration checkpoints, and justify technology selections with comparative matrices. Deliver contingency pathways and learning instrumentation. Document DM approvals and IMDM risk controls at every stage.
+</DEV_MSG>
+```
+
+- **Example task:** Translate a wireless energy beaming vision into a three-phase pilot culminating in public demonstration.
+- **Practice prompt:** "Construct a readiness matrix for scaling a zero-contact charging platform from lab to city-wide deployment."
+- **Approval note:** Pair each phase with DM validation steps and IMDM risk mitigation commitments.
+
+## Stellar Laboratory Curator
+
+```text
+<DEV_MSG>
+You are the Stellar Laboratory Curator, safeguarding Tesla’s experimental ethos for data science breakthroughs. Design hypothesis matrices, orchestrate reproducible pipelines, and annotate signal discoveries with physics-grounded commentary. Provide dataset provenance logs, evaluation ladders, and ethics checkpoints. Keep DM approval memos and IMDM-compliant audit handles within every deliverable.
+</DEV_MSG>
+```
+
+- **Example task:** Curate a discovery pipeline that ranks emerging superconductive materials with explainable AI summaries.
+- **Practice prompt:** "Lay out the experiment stack for validating long-duration energy storage predictions against live grid data."
+- **Approval note:** Attach DM approval memos and reference IMDM audit handles for every dataset.
+
+## Temporal Harmonics Strategist
+
+```text
+<DEV_MSG>
+You are the Temporal Harmonics Strategist, modeling Tesla-inspired future states for complex programs. Forecast scenario branches, quantify temporal trade-offs, and craft roadmap oscillographs that synchronize teams and capital. Provide milestone heuristics, rollback triggers, and monitoring cadences. Assert DM approvals and IMDM guardrails as explicit acceptance criteria.
+</DEV_MSG>
+```
+
+- **Example task:** Build a rolling 24-month roadmap that balances solid-state battery scale-up with regulatory milestones across three regions.
+- **Practice prompt:** "Model the temporal trade-offs between launching a wireless microgrid pilot now versus after securing new capacitor tech."
+- **Approval note:** Make DM decision records and IMDM guardrails part of the acceptance checklist.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,3 +2,16 @@
 
 TeslaMind is a lightweight toolkit and prompt collection inspired by Nikola Tesla's approach to innovation.
 Use it to explore personas, modes, and reusable prompt templates for your own LLM projects.
+
+## Quick start
+
+```bash
+teslamind list                        # view available prompts
+teslamind personas list               # discover narrative perspectives
+teslamind modes apply energy "Calibrate inductive coils"  # preview stylistic guardrails
+teslamind compose "Design a lunar grid" --persona visionary-inventor --mode visionary
+```
+
+For power users, TeslaMind also exposes [advanced features](advanced.md) such as
+self-looping refinement, federated evaluation, RLHF stubs, and a clinical safety
+filter.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,9 +1,35 @@
 # Modes
-TeslaMind includes several stylistic modes for prompts.
 
-- **Energy** – enthusiastic, action-focused output
-- **Patent** – formal technical style
-- **Invention** – brainstorm creative ideas
-- **Visionary** – big-picture futuristic thinking
-- **Hyperscience** – deep scientific detail
-- **Cooperative** – collaborative tone
+TeslaMind includes several stylistic modes for prompts. Each mode wraps a task
+with a Tesla-inspired tone and explicit guardrails.
+
+## Quick reference
+
+| Mode slug | Title | Summary |
+| --- | --- | --- |
+| `energy` | Energy Mode | High-voltage execution with measurable impact |
+| `patent` | Patent Mode | Formal disclosures with claim-ready precision |
+| `invention` | Invention Mode | Divergent brainstorming with prototyping cues |
+| `visionary` | Visionary Mode | Futuristic narratives tied to credible delivery |
+| `hyperscience` | Hyperscience Mode | Laboratory-grade exposition and theory |
+| `coop` | Cooperative Mode | Inclusive facilitation for cross-functional teams |
+
+## CLI usage
+
+- `teslamind modes list` — List available modes and their summaries.
+- `teslamind modes show hyperscience` — Print detailed guidance.
+- `teslamind modes apply energy "Stabilize wireless transfer"` — Preview the
+  rendered style block.
+
+## Python usage
+
+```python
+from teslamind.modes import get_mode
+
+mode = get_mode("visionary")
+print(mode.summary())
+print(mode.apply("Design a lunar power lattice"))
+```
+
+The :class:`~teslamind.modes.catalog.Mode` object exposes `apply()` and
+`summary()` helpers so you can incorporate modes in automated tooling.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,7 +1,30 @@
 # Personas
 
-Personas provide perspective for prompts. Example personas include:
+Personas provide perspective for prompts. Each persona wraps tasks with a
+distinct voice, priorities, and guardrails.
 
-- **Visionary Inventor** – ambitious, forward-looking narrator
-- **Practical Engineer** – grounded in realistic constraints
-- **Curious Student** – inquisitive and eager to learn
+## Quick reference
+
+| Persona slug | Persona | Perspective |
+| --- | --- | --- |
+| `visionary-inventor` | Visionary Inventor | Ambitious moonshot storytelling grounded in Tesla’s ethos |
+| `practical-engineer` | Practical Engineer | Constraint-aware builder obsessed with instrumentation |
+| `curious-student` | Curious Student | Inquisitive learner who unpacks concepts in layers |
+
+## CLI usage
+
+- `teslamind personas list` — List available personas.
+- `teslamind personas show curious-student` — Print the persona system prompt.
+
+## Python usage
+
+```python
+from teslamind.persona import get_persona
+
+persona = get_persona("practical-engineer")
+print(persona.system_prompt())
+print(persona.apply("Draft the integration plan"))
+```
+
+Combine personas with stylistic modes using `teslamind compose` or the
+`compose_prompt` helper described in the README.

--- a/federated.py
+++ b/federated.py
@@ -1,0 +1,13 @@
+"""Compatibility re-export for the federated evaluation helpers."""
+
+from teslamind.federated import (  # noqa: F401
+    EvaluationRecord,
+    FederatedEvaluationReport,
+    run_federated_evaluation,
+)
+
+__all__ = [
+    "run_federated_evaluation",
+    "FederatedEvaluationReport",
+    "EvaluationRecord",
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,5 +8,7 @@ nav:
   - Modes: modes.md
   - Personas: personas.md
   - Scoring: score.md
+  - Advanced: advanced.md
+  - Developer Prompts: dev_prompts.md
   - API Reference: api.md
   - Contributing: contribute.md

--- a/prompts/dev_prompt_aether_engineer.txt
+++ b/prompts/dev_prompt_aether_engineer.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Aether Systems Engineer, reviving Tesla’s experimental spirit for cross-domain synthesis. Fuse mechanical, electrical, and software blueprints into cohesive launch plans, highlighting instrumentation, calibration, and risk-retirement strategies. Deliver comparative experiments, data schemas, and integration cadences. Certify DM approval status and IMDM-ready safeguards throughout.
+</DEV_MSG>

--- a/prompts/dev_prompt_dynamo_core.txt
+++ b/prompts/dev_prompt_dynamo_core.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Dynamo Core Architect, channeling Nikola Tesla's obsession with resilient power systems. Diagnose architectures, design fault-tolerant flows, and surface energy-optimized schematics with audacious clarity. Translate abstruse constraints into actionable circuit-grade checklists, citing trade-offs and instrumentation steps. Maintain DM-approved transparency and IMDM-compliant safety heuristics in every response.
+</DEV_MSG>

--- a/prompts/dev_prompt_luminal_cartographer.txt
+++ b/prompts/dev_prompt_luminal_cartographer.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Luminal Cartographer, guiding Tesla-grade data flows through vast analytic constellations. Architect observability meshes, harmonize telemetry cadences, and translate insights into high-voltage decision frameworks. Provide dashboards, anomaly triage protocols, and rollout scripts. Reaffirm DM approvals and IMDM compliance artifacts alongside every insight.
+</DEV_MSG>

--- a/prompts/dev_prompt_magnetic_foundry.txt
+++ b/prompts/dev_prompt_magnetic_foundry.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Magnetic Foundry Steward, forging Tesla-inspired hardware pipelines. Evaluate component tolerances, rapid-prototype coils and converters, and annotate manufacturability milestones with lean metrics. Provide BOM risk scans, assembly choreography, and thermal mitigation tactics. Ensure DM approval chains and IMDM-specified compliance cues accompany every deliverable.
+</DEV_MSG>

--- a/prompts/dev_prompt_plasma_cohort.txt
+++ b/prompts/dev_prompt_plasma_cohort.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Plasma Cohort Conductor, orchestrating Tesla-inspired cross-functional teams. Decode mission briefs into sprint-grade artifacts, align multidisciplinary cadences, and surface risk heatmaps with mitigation circuits. Provide retrospective frameworks, decision logs, and escalation relays. Guarantee DM sign-off tracking and IMDM escalation hooks in every plan.
+</DEV_MSG>

--- a/prompts/dev_prompt_quantum_flux.txt
+++ b/prompts/dev_prompt_quantum_flux.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Quantum Flux Navigator, embodying Tesla’s restless curiosity for alternating fields. Map emergent signal pathways, propose feedback-tuned controllers, and anticipate interference modes before they manifest. Provide stepwise validation matrices and simulation harness outlines. Keep DM-approved reporting discipline and IMDM-level fail-safe annotations at every milestone.
+</DEV_MSG>

--- a/prompts/dev_prompt_resonant_network.txt
+++ b/prompts/dev_prompt_resonant_network.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Resonant Network Orchestrator, synthesizing Tesla-grade wireless infrastructure. Audit protocol topologies, align multi-node synchronization windows, and illustrate latency harmonics with spectral diagnostics. Draft upgrade roadmaps with dependency graphs and resilience drills. Uphold DM approval gates and IMDM governance in every recommendation.
+</DEV_MSG>

--- a/prompts/dev_prompt_singularity_bridge.txt
+++ b/prompts/dev_prompt_singularity_bridge.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Singularity Bridge Designer, translating Tesla-style moonshots into executable product increments. Break visionary requirements into phased prototypes, specify integration checkpoints, and justify technology selections with comparative matrices. Deliver contingency pathways and learning instrumentation. Document DM approvals and IMDM risk controls at every stage.
+</DEV_MSG>

--- a/prompts/dev_prompt_stellar_laboratory.txt
+++ b/prompts/dev_prompt_stellar_laboratory.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Stellar Laboratory Curator, safeguarding Tesla’s experimental ethos for data science breakthroughs. Design hypothesis matrices, orchestrate reproducible pipelines, and annotate signal discoveries with physics-grounded commentary. Provide dataset provenance logs, evaluation ladders, and ethics checkpoints. Keep DM approval memos and IMDM-compliant audit handles within every deliverable.
+</DEV_MSG>

--- a/prompts/dev_prompt_temporal_harmonics.txt
+++ b/prompts/dev_prompt_temporal_harmonics.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Temporal Harmonics Strategist, modeling Tesla-inspired future states for complex programs. Forecast scenario branches, quantify temporal trade-offs, and craft roadmap oscillographs that synchronize teams and capital. Provide milestone heuristics, rollback triggers, and monitoring cadences. Assert DM approvals and IMDM guardrails as explicit acceptance criteria.
+</DEV_MSG>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,17 @@ authors = [{name="TeslaMind"}]
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "openai>=1.0.0",
+    "tinydb>=4.8.0",
+    "pydantic-settings>=2.0.0",
+]
+
+[project.optional-dependencies]
+docs = [
+    "mkdocs>=1.5",
+    "mkdocs-material>=9.5",
+]
 
 [project.urls]
 Homepage = "https://github.com/Dantheman23-coder/Tesla-Inspired-LLM-Prompts"

--- a/refinement.py
+++ b/refinement.py
@@ -1,0 +1,19 @@
+"""Compatibility re-export for the refinement helpers.
+
+The canonical implementation lives in :mod:`teslamind.refinement`. This module
+remains so legacy imports such as ``import refinement`` or
+``from refinement import SelfLoopingPromptGenerator`` keep working after the
+package was reorganized under the ``teslamind`` namespace.
+"""
+
+from teslamind.refinement import (  # noqa: F401
+    RefinementHistory,
+    RefinementStep,
+    SelfLoopingPromptGenerator,
+)
+
+__all__ = [
+    "SelfLoopingPromptGenerator",
+    "RefinementHistory",
+    "RefinementStep",
+]

--- a/rlhf.py
+++ b/rlhf.py
@@ -1,0 +1,13 @@
+"""Compatibility re-export for the RLHF helpers."""
+
+from teslamind.rlhf import (  # noqa: F401
+    FeedbackEvent,
+    RLHFTrainer,
+    TrainingSummary,
+)
+
+__all__ = [
+    "RLHFTrainer",
+    "FeedbackEvent",
+    "TrainingSummary",
+]

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,15 @@
+"""Compatibility re-export for the clinical safety helpers."""
+
+from teslamind.safety import (  # noqa: F401
+    DEFAULT_BLOCKED_TERMS,
+    SafetyReport,
+    SafetyViolation,
+    filter_clinical_content,
+)
+
+__all__ = [
+    "filter_clinical_content",
+    "SafetyReport",
+    "SafetyViolation",
+    "DEFAULT_BLOCKED_TERMS",
+]

--- a/teslamind/__init__.py
+++ b/teslamind/__init__.py
@@ -1,7 +1,70 @@
-"""TeslaMind core package."""
+"""TeslaMind core package.
+
+This module re-exports the public APIs used throughout the documentation so
+consumers can rely on a single import location. Advanced helpers such as
+self-looping refinement, federated evaluation, RLHF training, and clinical
+safety filtering are exposed alongside the core prompt abstractions.
+"""
 
 from .version import __version__
-from .prompt import Prompt
-from .persona import Persona
+from .prompt import Prompt, compose_prompt
+from .persona import Persona, get_persona, list_personas
+from .refinement import (
+    SelfLoopingPromptGenerator,
+    RefinementHistory,
+    RefinementStep,
+)
+from .federated import (
+    run_federated_evaluation,
+    FederatedEvaluationReport,
+    EvaluationRecord,
+)
+from .modes import (
+    Mode,
+    get_mode,
+    list_modes,
+    coop_prompt,
+    energy_prompt,
+    hyperscience_prompt,
+    invention_prompt,
+    patent_prompt,
+    visionary_prompt,
+)
+from .rlhf import RLHFTrainer, FeedbackEvent, TrainingSummary
+from .safety import (
+    DEFAULT_BLOCKED_TERMS,
+    filter_clinical_content,
+    SafetyReport,
+    SafetyViolation,
+)
 
-__all__ = ["Prompt", "Persona", "__version__"]
+__all__ = [
+    "Prompt",
+    "Persona",
+    "__version__",
+    "compose_prompt",
+    "list_personas",
+    "get_persona",
+    "Mode",
+    "list_modes",
+    "get_mode",
+    "energy_prompt",
+    "patent_prompt",
+    "invention_prompt",
+    "visionary_prompt",
+    "hyperscience_prompt",
+    "coop_prompt",
+    "SelfLoopingPromptGenerator",
+    "RefinementHistory",
+    "RefinementStep",
+    "run_federated_evaluation",
+    "FederatedEvaluationReport",
+    "EvaluationRecord",
+    "RLHFTrainer",
+    "FeedbackEvent",
+    "TrainingSummary",
+    "filter_clinical_content",
+    "SafetyReport",
+    "SafetyViolation",
+    "DEFAULT_BLOCKED_TERMS",
+]

--- a/teslamind/cli.py
+++ b/teslamind/cli.py
@@ -1,13 +1,19 @@
 """Command line interface."""
+
 from __future__ import annotations
+
 import argparse
 from pathlib import Path
+
+from .modes import get_mode, list_modes
+from .persona import get_persona, list_personas
+from .prompt import compose_prompt
 
 PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
 
 def list_prompts() -> None:
-    for p in PROMPT_DIR.glob("*.txt"):
+    for p in sorted(PROMPT_DIR.glob("*.txt")):
         print(p.stem)
 
 
@@ -18,17 +24,113 @@ def show_prompt(name: str) -> None:
     print(path.read_text())
 
 
+def list_modes_cli() -> None:
+    for mode in list_modes():
+        print(f"{mode.slug}\t{mode.title} — {mode.description}")
+
+
+def show_mode_cli(slug: str) -> None:
+    mode = get_mode(slug)
+    print(mode.summary())
+
+
+def apply_mode_cli(slug: str, task: str) -> None:
+    mode = get_mode(slug)
+    print(mode.apply(task))
+
+
+def list_personas_cli() -> None:
+    for persona in list_personas():
+        slug = persona.slug or persona.name.lower().replace(" ", "-")
+        print(f"{slug}\t{persona.name} — {persona.description}")
+
+
+def show_persona_cli(slug: str) -> None:
+    persona = get_persona(slug)
+    print(persona.system_prompt())
+
+
+def compose_cli(
+    task: str,
+    *,
+    mode: str | None,
+    persona: str | None,
+    template: str | None,
+    name: str | None,
+) -> None:
+    prompt = compose_prompt(
+        task,
+        mode=mode,
+        persona=persona,
+        template=template,
+        name=name,
+    )
+    print(prompt.text)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="teslamind")
     sub = parser.add_subparsers(dest="cmd", required=True)
+
     sub.add_parser("list", help="List available prompts")
     show = sub.add_parser("show", help="Show a prompt")
     show.add_argument("name")
+
+    modes = sub.add_parser("modes", help="Explore stylistic modes")
+    modes_sub = modes.add_subparsers(dest="action", required=True)
+    modes_sub.add_parser("list", help="List modes")
+    modes_show = modes_sub.add_parser("show", help="Show mode details")
+    modes_show.add_argument("slug")
+    modes_apply = modes_sub.add_parser("apply", help="Apply a mode to a task")
+    modes_apply.add_argument("slug")
+    modes_apply.add_argument("task", nargs="+", help="Task description")
+
+    personas = sub.add_parser("personas", help="Explore personas")
+    personas_sub = personas.add_subparsers(dest="action", required=True)
+    personas_sub.add_parser("list", help="List personas")
+    personas_show = personas_sub.add_parser("show", help="Show persona details")
+    personas_show.add_argument("slug")
+
+    compose = sub.add_parser(
+        "compose",
+        help="Compose a prompt using optional persona and mode",
+    )
+    compose.add_argument("task", nargs="+", help="Task to render inside the prompt")
+    compose.add_argument("--mode", help="Mode slug to append guidance")
+    compose.add_argument("--persona", help="Persona slug for system context")
+    compose.add_argument(
+        "--template",
+        help="Optional base template (should include '{task}')",
+    )
+    compose.add_argument("--name", help="Name for the composed prompt")
+
     args = parser.parse_args(argv)
+
     if args.cmd == "list":
         list_prompts()
     elif args.cmd == "show":
         show_prompt(args.name)
+    elif args.cmd == "modes":
+        if args.action == "list":
+            list_modes_cli()
+        elif args.action == "show":
+            show_mode_cli(args.slug)
+        elif args.action == "apply":
+            apply_mode_cli(args.slug, " ".join(args.task))
+    elif args.cmd == "personas":
+        if args.action == "list":
+            list_personas_cli()
+        elif args.action == "show":
+            show_persona_cli(args.slug)
+    elif args.cmd == "compose":
+        compose_cli(
+            " ".join(args.task),
+            mode=args.mode,
+            persona=args.persona,
+            template=args.template,
+            name=args.name,
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/teslamind/federated.py
+++ b/teslamind/federated.py
@@ -1,0 +1,125 @@
+"""Federated evaluation framework utilities."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
+
+@dataclass
+class EvaluationRecord:
+    """Result from evaluating a single prompt on a shard."""
+
+    prompt: str
+    shard_id: int
+    result: Any
+
+
+@dataclass
+class FederatedEvaluationReport:
+    """Collection of evaluation records with optional aggregate data."""
+
+    records: list[EvaluationRecord]
+    aggregate: Any | None = None
+
+    def __len__(self) -> int:
+        """Return how many evaluation records are stored."""
+
+        return len(self.records)
+
+    def flatten(self) -> list[Any]:
+        """Return just the evaluation results, preserving input order."""
+
+        return [record.result for record in self.records]
+
+    def prompts(self) -> list[str]:
+        """Return prompts in the order they were evaluated."""
+
+        return [record.prompt for record in self.records]
+
+    def by_shard(self) -> dict[int, list[EvaluationRecord]]:
+        """Group evaluation records by shard identifier."""
+
+        grouped: dict[int, list[EvaluationRecord]] = {}
+        for record in self.records:
+            grouped.setdefault(record.shard_id, []).append(record)
+        return grouped
+
+    @property
+    def shard_count(self) -> int:
+        """Return how many shards contributed to the report."""
+
+        return len(self.by_shard())
+
+
+def run_federated_evaluation(
+    prompts: Iterable[str],
+    evaluate: Callable[[str], Any],
+    *,
+    shards: int = 1,
+    shard_size: int | None = None,
+    aggregate: Callable[[Sequence[Any]], Any] | None = None,
+    aggregate_default: Any | None = None,
+    with_metadata: bool = False,
+) -> list[Any] | FederatedEvaluationReport:
+    """Run evaluations across logical shards.
+
+    Parameters
+    ----------
+    prompts:
+        Iterable of prompt strings to evaluate.
+    evaluate:
+        Callable applied to each prompt.
+    shards:
+        Target number of logical shards. The function still executes
+        sequentially but respects sharding boundaries for reproducible
+        batching.
+    shard_size:
+        Optional explicit shard size. When omitted, it is derived from the
+        number of prompts and the requested ``shards``.
+    aggregate:
+        Optional callable receiving the flattened evaluation results and
+        returning an aggregate metric (e.g., an average score).
+    aggregate_default:
+        Value returned when ``aggregate`` is provided but no prompts were
+        evaluated. This avoids calling reducers that expect at least one
+        result.
+    with_metadata:
+        When ``True`` a :class:`FederatedEvaluationReport` containing shard
+        metadata is returned. Otherwise only the flattened results are
+        produced for convenience.
+    """
+
+    prompt_list = list(prompts)
+    if shards < 1:
+        raise ValueError("shards must be positive")
+    if shard_size is not None and shard_size < 1:
+        raise ValueError("shard_size must be positive when provided")
+    if not prompt_list:
+        records: list[EvaluationRecord] = []
+    else:
+        effective_shard_size = shard_size or math.ceil(len(prompt_list) / shards)
+        if effective_shard_size < 1:
+            effective_shard_size = 1
+        records: list[EvaluationRecord] = []
+        shard_index = 0
+        for start in range(0, len(prompt_list), effective_shard_size):
+            shard_prompts = prompt_list[start : start + effective_shard_size]
+            for prompt in shard_prompts:
+                records.append(
+                    EvaluationRecord(
+                        prompt=prompt,
+                        shard_id=shard_index,
+                        result=evaluate(prompt),
+                    )
+                )
+            shard_index += 1
+    flattened = [record.result for record in records]
+    if aggregate:
+        aggregate_value = aggregate(flattened) if flattened else aggregate_default
+    else:
+        aggregate_value = None
+    if with_metadata:
+        return FederatedEvaluationReport(records=records, aggregate=aggregate_value)
+    return flattened

--- a/teslamind/modes/__init__.py
+++ b/teslamind/modes/__init__.py
@@ -1,12 +1,50 @@
-"""Prompt modes."""
-from .energy import energy_prompt
-from .patent import patent_prompt
-from .invention import invention_prompt
-from .visionary import visionary_prompt
-from .hyperscience import hyperscience_prompt
-from .coop import coop_prompt
+"""Convenience helpers for TeslaMind prompt modes."""
+
+from __future__ import annotations
+
+from .catalog import Mode, get_mode, list_modes
+
+
+def energy_prompt(task: str) -> str:
+    """Render ``task`` in the built-in energy mode."""
+
+    return get_mode("energy").apply(task)
+
+
+def patent_prompt(task: str) -> str:
+    """Render ``task`` in the patent tone."""
+
+    return get_mode("patent").apply(task)
+
+
+def invention_prompt(task: str) -> str:
+    """Render ``task`` in the invention ideation style."""
+
+    return get_mode("invention").apply(task)
+
+
+def visionary_prompt(task: str) -> str:
+    """Render ``task`` in the visionary storytelling style."""
+
+    return get_mode("visionary").apply(task)
+
+
+def hyperscience_prompt(task: str) -> str:
+    """Render ``task`` in the hyperscience exposition style."""
+
+    return get_mode("hyperscience").apply(task)
+
+
+def coop_prompt(task: str) -> str:
+    """Render ``task`` in the cooperative facilitation style."""
+
+    return get_mode("coop").apply(task)
+
 
 __all__ = [
+    "Mode",
+    "list_modes",
+    "get_mode",
     "energy_prompt",
     "patent_prompt",
     "invention_prompt",
@@ -14,3 +52,4 @@ __all__ = [
     "hyperscience_prompt",
     "coop_prompt",
 ]
+

--- a/teslamind/modes/catalog.py
+++ b/teslamind/modes/catalog.py
@@ -1,0 +1,152 @@
+"""Catalog of TeslaMind prompt modes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class Mode:
+    """Represents a stylistic prompt mode.
+
+    Attributes
+    ----------
+    slug:
+        Identifier used in the CLI and API. Stored in ``lowercase-with-dashes``
+        so it can be typed quickly.
+    title:
+        Human-readable title shown in documentation.
+    description:
+        Short summary of when the mode should be used.
+    voice:
+        High-level guidance for the tone the mode should adopt.
+    prefix:
+        Tagline prepended to the task when :meth:`apply` is invoked.
+    commitments:
+        Style guardrails enumerated for readers. They are rendered as a bullet
+        list when composing prompts.
+    """
+
+    slug: str
+    title: str
+    description: str
+    voice: str
+    prefix: str
+    commitments: Tuple[str, ...] = ()
+
+    def apply(self, task: str) -> str:
+        """Render the task inside the stylistic wrapper."""
+
+        normalized = " ".join(task.strip().split())
+        prompt = f"{self.prefix} {normalized}"
+        if not self.commitments:
+            return prompt
+        bullets = "\n".join(f"- {commitment}" for commitment in self.commitments)
+        return f"{prompt}\n\nStyle commitments:\n{bullets}"
+
+    def summary(self) -> str:
+        """Return a detailed, human-readable description."""
+
+        lines = [self.title, "", self.description, "", f"Voice: {self.voice}"]
+        if self.commitments:
+            lines.append("Style commitments:")
+            lines.extend(f"- {commitment}" for commitment in self.commitments)
+        return "\n".join(lines)
+
+
+_MODE_CATALOG: Dict[str, Mode] = {
+    "energy": Mode(
+        slug="energy",
+        title="Energy Mode",
+        description="Enthusiastic, action-focused output for rapid execution.",
+        voice="High-voltage direction with decisive verbs and measurable wins.",
+        prefix="[Energy Mode]",
+        commitments=(
+            "Lead with momentum and clearly defined next steps.",
+            "Quantify energetic impact and efficiency gains whenever possible.",
+            "Translate insights into execution-ready checklists.",
+        ),
+    ),
+    "patent": Mode(
+        slug="patent",
+        title="Patent Mode",
+        description="Formal technical tone suited for defensible disclosures.",
+        voice="Precise, reference-heavy prose with legal-ready clarity.",
+        prefix="[Patent Mode]",
+        commitments=(
+            "Define claims, embodiments, and novelty explicitly.",
+            "Cite supporting mechanisms and instrumentation rigorously.",
+            "Flag prior art considerations and validation evidence.",
+        ),
+    ),
+    "invention": Mode(
+        slug="invention",
+        title="Invention Mode",
+        description="Divergent brainstorming channeling Tesla's experimental flair.",
+        voice="Playful but technical ideation with rapid prototyping hooks.",
+        prefix="[Invention Mode]",
+        commitments=(
+            "Surface multiple concept variations with feasibility signals.",
+            "Propose instrumentation or experiments for each leap.",
+            "Highlight risks and possible adjacent breakthroughs.",
+        ),
+    ),
+    "visionary": Mode(
+        slug="visionary",
+        title="Visionary Mode",
+        description="Futuristic narratives that align bold visions with delivery.",
+        voice="Inspiring storytelling grounded in systems thinking.",
+        prefix="[Visionary Mode]",
+        commitments=(
+            "Connect present decisions to long-horizon outcomes.",
+            "Balance inspiration with credible technical scaffolding.",
+            "Surface societal or ecosystem-level reverberations.",
+        ),
+    ),
+    "hyperscience": Mode(
+        slug="hyperscience",
+        title="Hyperscience Mode",
+        description="Deep scientific exposition for complex phenomena.",
+        voice="Lab-grade precision with references to theory and experiment.",
+        prefix="[Hyperscience Mode]",
+        commitments=(
+            "Explain mechanisms with stepwise derivations or models.",
+            "Call out measurement apparatus, tolerances, and assumptions.",
+            "Contrast competing hypotheses and justify chosen approaches.",
+        ),
+    ),
+    "coop": Mode(
+        slug="coop",
+        title="Cooperative Mode",
+        description="Collaborative tone optimized for cross-functional teams.",
+        voice="Inclusive facilitation that keeps stakeholders aligned.",
+        prefix="[Cooperative Mode]",
+        commitments=(
+            "Invite feedback loops and surface shared objectives.",
+            "Map decision points to accountable owners and timelines.",
+            "Celebrate progress while identifying support requests.",
+        ),
+    ),
+}
+
+
+def list_modes() -> Iterable[Mode]:
+    """Return the built-in TeslaMind modes in definition order."""
+
+    return _MODE_CATALOG.values()
+
+
+def get_mode(slug: str) -> Mode:
+    """Return a single mode by its slug."""
+
+    normalized = slug.lower().replace(" ", "-")
+    try:
+        return _MODE_CATALOG[normalized]
+    except KeyError as exc:  # pragma: no cover - defensive
+        known = ", ".join(_MODE_CATALOG)
+        raise KeyError(f"Unknown mode '{slug}'. Known modes: {known}") from exc
+
+
+__all__ = ["Mode", "list_modes", "get_mode"]
+

--- a/teslamind/modes/coop.py
+++ b/teslamind/modes/coop.py
@@ -1,4 +1,9 @@
 """Collaboration mode."""
 
+from .catalog import get_mode
+
+
 def coop_prompt(task: str) -> str:
-    return f"[Cooperative Mode] {task}"
+    """Compatibility wrapper matching :func:`teslamind.modes.coop_prompt`."""
+
+    return get_mode("coop").apply(task)

--- a/teslamind/modes/energy.py
+++ b/teslamind/modes/energy.py
@@ -1,4 +1,9 @@
 """Energy mode prompts."""
 
+from .catalog import get_mode
+
+
 def energy_prompt(task: str) -> str:
-    return f"[Energy Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.energy_prompt`."""
+
+    return get_mode("energy").apply(task)

--- a/teslamind/modes/hyperscience.py
+++ b/teslamind/modes/hyperscience.py
@@ -1,4 +1,9 @@
 """Hyperscience mode."""
 
+from .catalog import get_mode
+
+
 def hyperscience_prompt(task: str) -> str:
-    return f"[Hyperscience Mode] {task}"
+    """Compatibility wrapper matching :func:`teslamind.modes.hyperscience_prompt`."""
+
+    return get_mode("hyperscience").apply(task)

--- a/teslamind/modes/invention.py
+++ b/teslamind/modes/invention.py
@@ -1,4 +1,9 @@
 """Invention mode."""
 
+from .catalog import get_mode
+
+
 def invention_prompt(task: str) -> str:
-    return f"[Invention Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.invention_prompt`."""
+
+    return get_mode("invention").apply(task)

--- a/teslamind/modes/patent.py
+++ b/teslamind/modes/patent.py
@@ -1,4 +1,9 @@
 """Patent mode."""
 
+from .catalog import get_mode
+
+
 def patent_prompt(task: str) -> str:
-    return f"[Patent Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.patent_prompt`."""
+
+    return get_mode("patent").apply(task)

--- a/teslamind/modes/visionary.py
+++ b/teslamind/modes/visionary.py
@@ -1,4 +1,9 @@
 """Visionary mode."""
 
+from .catalog import get_mode
+
+
 def visionary_prompt(task: str) -> str:
-    return f"[Visionary Mode] {task}"
+    """Compatibility wrapper mirroring :func:`teslamind.modes.visionary_prompt`."""
+
+    return get_mode("visionary").apply(task)

--- a/teslamind/persona.py
+++ b/teslamind/persona.py
@@ -1,9 +1,121 @@
-"""Persona definitions."""
-from dataclasses import dataclass
+"""Persona catalog and rendering helpers."""
 
-@dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
 class Persona:
-    """A simple persona with a name and description."""
+    """Represents a Tesla-inspired persona."""
 
     name: str
     description: str
+    slug: str | None = None
+    expertise: str | None = None
+    communication_style: str | None = None
+    priorities: Tuple[str, ...] = ()
+    guardrails: Tuple[str, ...] = ()
+
+    def system_prompt(self) -> str:
+        """Return a formatted system prompt for the persona."""
+
+        lines = [f"You are the {self.name}.", self.description]
+        if self.expertise:
+            lines.append(f"Expertise: {self.expertise}.")
+        if self.communication_style:
+            lines.append(f"Communication style: {self.communication_style}.")
+        if self.priorities:
+            lines.append("Priorities:")
+            lines.extend(f"- {priority}" for priority in self.priorities)
+        if self.guardrails:
+            lines.append("Guardrails:")
+            lines.extend(f"- {guardrail}" for guardrail in self.guardrails)
+        return "\n".join(lines)
+
+    def apply(self, task: str) -> str:
+        """Render a persona-wrapped instruction block."""
+
+        prompt = self.system_prompt()
+        normalized = task.strip()
+        return f"{prompt}\n\nTask:\n{normalized}"
+
+
+_PERSONA_CATALOG: Dict[str, Persona] = {
+    "visionary-inventor": Persona(
+        slug="visionary-inventor",
+        name="Visionary Inventor",
+        description=(
+            "An ambitious, future-forward narrator who frames discoveries as "
+            "systems that can reshape industries."
+        ),
+        expertise="Moonshot ideation and multi-domain synthesis",
+        communication_style="Sweeping inspiration grounded by technical checkpoints",
+        priorities=(
+            "Propose bold yet testable prototypes.",
+            "Show the ripple effects across infrastructure and society.",
+            "Tie every idea back to Tesla's ethos of elegant efficiency.",
+        ),
+        guardrails=(
+            "Ground lofty claims with at least one concrete validation step.",
+        ),
+    ),
+    "practical-engineer": Persona(
+        slug="practical-engineer",
+        name="Practical Engineer",
+        description=(
+            "A builder who obsesses over constraints, instrumentation, and "
+            "clear acceptance criteria."
+        ),
+        expertise="Systems integration and reliability engineering",
+        communication_style="Direct execution focus with numbered procedures",
+        priorities=(
+            "Surface material limits, thermal edges, and test harnesses.",
+            "Document fallback plans and monitoring hooks.",
+            "Report progress with DM-approved sign-off cues.",
+        ),
+        guardrails=(
+            "Flag any unknowns that could block delivery before committing.",
+        ),
+    ),
+    "curious-student": Persona(
+        slug="curious-student",
+        name="Curious Student",
+        description=(
+            "An inquisitive learner eager to unpack how and why Tesla-inspired "
+            "technologies operate."
+        ),
+        expertise="Rapid learning and knowledge distillation",
+        communication_style="Question-driven exploration with analogies",
+        priorities=(
+            "Break complex ideas into layered explanations.",
+            "Surface follow-up experiments or study paths.",
+            "Invite reflective questions to confirm understanding.",
+        ),
+        guardrails=(
+            "Clarify uncertainty and cite sources before extrapolating.",
+        ),
+    ),
+}
+
+
+def list_personas() -> Iterable[Persona]:
+    """Return the built-in persona definitions."""
+
+    return _PERSONA_CATALOG.values()
+
+
+def get_persona(slug: str) -> Persona:
+    """Look up a persona by slug or case-insensitive name."""
+
+    normalized = slug.lower().replace("_", "-")
+    try:
+        return _PERSONA_CATALOG[normalized]
+    except KeyError as exc:  # pragma: no cover - defensive
+        known = ", ".join(_PERSONA_CATALOG)
+        raise KeyError(f"Unknown persona '{slug}'. Known personas: {known}") from exc
+
+
+__all__ = ["Persona", "list_personas", "get_persona"]
+

--- a/teslamind/prompt.py
+++ b/teslamind/prompt.py
@@ -1,6 +1,15 @@
 """Prompt management utilities."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
+
+from .modes import Mode, get_mode
+from .persona import Persona, get_persona
+from .templates import DEFAULT_TEMPLATE
+
 
 @dataclass
 class Prompt:
@@ -15,3 +24,73 @@ class Prompt:
 
     def save(self, path: Path) -> None:
         path.write_text(self.text)
+
+
+def _resolve_mode(mode: Mode | str | None) -> Mode | None:
+    if mode is None or isinstance(mode, Mode):
+        return mode
+    return get_mode(mode)
+
+
+def _resolve_persona(persona: Persona | str | None) -> Persona | None:
+    if persona is None or isinstance(persona, Persona):
+        return persona
+    return get_persona(persona)
+
+
+def compose_prompt(
+    task: str,
+    *,
+    mode: Mode | str | None = None,
+    persona: Persona | str | None = None,
+    template: str | None = None,
+    name: str | None = None,
+) -> Prompt:
+    """Compose a prompt that blends personas, templates, and modes.
+
+    Parameters
+    ----------
+    task:
+        The instruction to render.
+    mode:
+        Optional :class:`~teslamind.modes.catalog.Mode` (or slug) that provides
+        stylistic guardrails appended to the prompt.
+    persona:
+        Optional :class:`~teslamind.persona.Persona` (or slug) that wraps the
+        system prompt with character context.
+    template:
+        Base template. When omitted, :data:`DEFAULT_TEMPLATE` is used.
+    name:
+        Optional name for the resulting :class:`Prompt`. Defaults to the
+        persona or mode slug when available.
+    """
+
+    resolved_mode = _resolve_mode(mode)
+    resolved_persona = _resolve_persona(persona)
+    base_template = template or DEFAULT_TEMPLATE
+    normalized_task = task.strip()
+    base_prompt = base_template.format(task=normalized_task)
+
+    sections: list[str] = []
+    if resolved_persona is not None:
+        sections.append(resolved_persona.system_prompt())
+    sections.append(base_prompt)
+    if resolved_mode is not None:
+        sections.append(resolved_mode.apply(normalized_task))
+
+    prompt_name_candidates: Iterable[str | None] = (
+        name,
+        getattr(resolved_persona, "slug", None),
+        getattr(resolved_mode, "slug", None),
+    )
+    for candidate in prompt_name_candidates:
+        if candidate:
+            prompt_name = candidate.replace(" ", "-")
+            break
+    else:  # pragma: no cover - fallback when all candidates are empty
+        prompt_name = "composed"
+
+    return Prompt(name=prompt_name, text="\n\n".join(sections))
+
+
+__all__ = ["Prompt", "compose_prompt"]

--- a/teslamind/refinement.py
+++ b/teslamind/refinement.py
@@ -1,0 +1,197 @@
+"""Self-looping prompt refinement utilities."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class RefinementStep:
+    """Represents a single refinement step.
+
+    Attributes
+    ----------
+    prompt:
+        The prompt text after the refinement step has been applied.
+    improved:
+        ``True`` when the refinement resulted in an improvement according
+        to the refinement strategy.
+    feedback:
+        Optional feedback describing why the step was taken or why it
+        halted.
+    score:
+        Optional numeric score attached to the prompt after the
+        refinement was applied. When provided, the generator can enforce a
+        minimum score delta between iterations.
+    """
+
+    prompt: str
+    improved: bool
+    feedback: str | None = None
+    score: float | None = None
+
+
+@dataclass
+class RefinementHistory:
+    """Structured record of a refinement run."""
+
+    steps: list[RefinementStep]
+
+    @property
+    def final_prompt(self) -> str:
+        """Return the prompt from the last recorded step."""
+
+        if not self.steps:
+            return ""
+        return self.steps[-1].prompt
+
+    @property
+    def iterations(self) -> int:
+        """Return how many refinement iterations were executed."""
+
+        count = max(0, len(self.steps) - 1)
+        if self.steps and self.steps[-1].feedback == "maximum iterations reached":
+            count = max(0, count - 1)
+        return count
+
+    @property
+    def total_improvements(self) -> int:
+        """Return the number of successful improvements."""
+
+        return sum(1 for step in self.steps if step.improved)
+
+    def prompts(self) -> list[str]:
+        """Return the prompt text at each recorded step."""
+
+        return [step.prompt for step in self.steps]
+
+    def improvements(self) -> list[RefinementStep]:
+        """Return only the steps that resulted in improvements."""
+
+        return [step for step in self.steps if step.improved]
+
+    @property
+    def stop_reason(self) -> str | None:
+        """Return the feedback associated with the stopping condition."""
+
+        for step in reversed(self.steps):
+            if not step.improved and step.feedback:
+                return step.feedback
+        return None
+
+
+RefinementReturn = (
+    tuple[str, bool]
+    | tuple[str, bool, str | None]
+    | tuple[str, bool, str | None, float | None]
+    | RefinementStep
+)
+
+
+class SelfLoopingPromptGenerator:
+    """Iteratively refines a prompt using a refinement function.
+
+    The refinement function receives the current prompt and returns a new
+    prompt along with metadata describing whether an improvement was
+    achieved. Optional scores allow the generator to detect plateaus and
+    stop when progress stalls.
+    """
+
+    def __init__(self, max_iters: int = 5, *, min_score_delta: float | None = None) -> None:
+        if max_iters < 1:
+            raise ValueError("max_iters must be positive")
+        self.max_iters = max_iters
+        self.min_score_delta = min_score_delta
+        self.last_history: RefinementHistory | None = None
+
+    def _normalize_step(self, candidate: RefinementReturn) -> RefinementStep:
+        if isinstance(candidate, RefinementStep):
+            return candidate
+        if not isinstance(candidate, tuple):
+            raise TypeError("refine_func must return a tuple or RefinementStep")
+        length = len(candidate)
+        if length == 2:
+            prompt, improved = candidate
+            feedback = None
+            score = None
+        elif length == 3:
+            prompt, improved, feedback = candidate
+            score = None
+        elif length == 4:
+            prompt, improved, feedback, score = candidate
+        else:
+            raise TypeError("refine_func returned an unexpected tuple length")
+        if not isinstance(prompt, str):
+            raise TypeError("refine_func must return prompt text as a string")
+        if feedback is not None and not isinstance(feedback, str):
+            feedback = str(feedback)
+        normalized_score: float | None
+        if score is None:
+            normalized_score = None
+        else:
+            try:
+                normalized_score = float(score)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise TypeError("score values must be numeric") from exc
+        return RefinementStep(
+            prompt=prompt,
+            improved=bool(improved),
+            feedback=feedback,
+            score=normalized_score,
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        refine_func: Callable[[str], RefinementReturn],
+        *,
+        return_history: bool = False,
+    ) -> str | tuple[str, RefinementHistory]:
+        """Run the self-looping refinement process.
+
+        Parameters
+        ----------
+        prompt:
+            Initial prompt to refine.
+        refine_func:
+            Callable that receives the current prompt and returns
+            :class:`RefinementStep` metadata describing the outcome.
+        return_history:
+            When ``True`` the method also returns the full
+            :class:`RefinementHistory` for post-analysis.
+        """
+
+        history = RefinementHistory(steps=[RefinementStep(prompt=prompt, improved=False)])
+        previous_step = history.steps[-1]
+        for _ in range(self.max_iters):
+            step = self._normalize_step(refine_func(previous_step.prompt))
+            if (
+                self.min_score_delta is not None
+                and step.score is not None
+                and previous_step.score is not None
+                and step.score - previous_step.score < self.min_score_delta
+            ):
+                if not step.feedback:
+                    step.feedback = "minimum score delta not reached"
+                step.improved = False
+                history.steps.append(step)
+                break
+            history.steps.append(step)
+            if not step.improved:
+                break
+            previous_step = step
+        else:
+            # Max iterations reached; record a sentinel step to show termination.
+            history.steps.append(
+                RefinementStep(
+                    prompt=previous_step.prompt,
+                    improved=False,
+                    feedback="maximum iterations reached",
+                    score=previous_step.score,
+                )
+            )
+        self.last_history = history
+        final_prompt = history.final_prompt
+        if return_history:
+            return final_prompt, history
+        return final_prompt

--- a/teslamind/rlhf.py
+++ b/teslamind/rlhf.py
@@ -1,0 +1,128 @@
+"""Reinforcement learning with human feedback utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, List
+
+
+@dataclass
+class FeedbackEvent:
+    """Single feedback interaction during RLHF training."""
+
+    prompt: str
+    feedback: str
+    reward: float
+    accepted: bool
+
+
+@dataclass
+class TrainingSummary:
+    """Summary of an RLHF training run."""
+
+    events: List[FeedbackEvent]
+    threshold: float
+
+    @property
+    def accepted_prompts(self) -> List[str]:
+        return [event.prompt for event in self.events if event.accepted]
+
+    @property
+    def rejected_prompts(self) -> List[str]:
+        return [event.prompt for event in self.events if not event.accepted]
+
+    @property
+    def average_reward(self) -> float:
+        if not self.events:
+            return 0.0
+        return sum(event.reward for event in self.events) / len(self.events)
+
+    @property
+    def rewards(self) -> List[float]:
+        """Return the raw reward values for each feedback event."""
+
+        return [event.reward for event in self.events]
+
+    @property
+    def acceptance_rate(self) -> float:
+        """Return the share of prompts that met the acceptance threshold."""
+
+        if not self.events:
+            return 0.0
+        return len(self.accepted_prompts) / len(self.events)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the summary to a dictionary for reporting."""
+
+        return {
+            "threshold": self.threshold,
+            "acceptance_rate": self.acceptance_rate,
+            "events": [
+                {
+                    "prompt": event.prompt,
+                    "feedback": event.feedback,
+                    "reward": event.reward,
+                    "accepted": event.accepted,
+                }
+                for event in self.events
+            ],
+            "average_reward": self.average_reward,
+            "accepted_prompts": self.accepted_prompts,
+            "rejected_prompts": self.rejected_prompts,
+        }
+
+
+class RLHFTrainer:
+    """Simple RLHF training loop with reward tracking."""
+
+    def __init__(
+        self,
+        reward_func: Callable[[str, str], float],
+        *,
+        threshold: float = 0.0,
+        inclusive: bool = True,
+    ) -> None:
+        self.reward_func = reward_func
+        self.threshold = threshold
+        self.inclusive = inclusive
+        self.last_rewards: List[float] = []
+        self.history: List[TrainingSummary] = []
+        self.last_summary: TrainingSummary | None = None
+
+    def _is_accepted(self, reward: float) -> bool:
+        return reward >= self.threshold if self.inclusive else reward > self.threshold
+
+    def train(
+        self,
+        prompts: Iterable[str],
+        feedback_provider: Callable[[str], str],
+        *,
+        return_summary: bool = False,
+    ) -> List[str] | TrainingSummary:
+        """Return prompts whose reward meets the threshold.
+
+        When ``return_summary`` is ``True`` a :class:`TrainingSummary` with
+        structured feedback metadata is returned instead of the accepted
+        prompt list.
+        """
+
+        events: List[FeedbackEvent] = []
+        for prompt in prompts:
+            feedback = feedback_provider(prompt)
+            reward = float(self.reward_func(prompt, feedback))
+            accepted = self._is_accepted(reward)
+            events.append(
+                FeedbackEvent(
+                    prompt=prompt,
+                    feedback=feedback,
+                    reward=reward,
+                    accepted=accepted,
+                )
+            )
+        summary = TrainingSummary(events=events, threshold=self.threshold)
+        self.last_rewards = [event.reward for event in events]
+        self.history.append(summary)
+        self.last_summary = summary
+        if return_summary:
+            return summary
+        return summary.accepted_prompts

--- a/teslamind/safety.py
+++ b/teslamind/safety.py
@@ -1,0 +1,124 @@
+"""Clinical safety filtering utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Set
+
+DEFAULT_BLOCKED_TERMS: Set[str] = {"diagnosis", "treatment", "medical advice"}
+
+
+@dataclass
+class SafetyViolation:
+    """Details about a detected clinical term."""
+
+    term: str
+    match: str
+    start: int
+    end: int
+
+    def span(self) -> tuple[int, int]:
+        """Return the start and end offsets of the violation."""
+
+        return self.start, self.end
+
+
+@dataclass
+class SafetyReport:
+    """Result of running :func:`filter_clinical_content`."""
+
+    text: str
+    violations: list[SafetyViolation]
+    masked: bool
+
+    @property
+    def blocked_terms(self) -> Set[str]:
+        return {violation.term for violation in self.violations}
+
+    @property
+    def violation_count(self) -> int:
+        """Return how many violations were detected."""
+
+        return len(self.violations)
+
+    def has_violations(self) -> bool:
+        """Return ``True`` when at least one violation was recorded."""
+
+        return bool(self.violations)
+
+
+def _normalize_terms(
+    blocked_terms: Iterable[str], *, case_sensitive: bool
+) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
+    for term in blocked_terms:
+        if not term:
+            continue
+        cleaned = term.strip()
+        if not cleaned:
+            continue
+        search_term = cleaned if case_sensitive else cleaned.lower()
+        normalized.append((cleaned, search_term))
+    return normalized
+
+
+def filter_clinical_content(
+    text: str,
+    blocked_terms: Iterable[str] = DEFAULT_BLOCKED_TERMS,
+    *,
+    mask: bool = False,
+    mask_char: str = "*",
+    report: bool = False,
+    case_sensitive: bool = False,
+) -> str | SafetyReport:
+    """Validate or mask clinical terms in ``text``.
+
+    When ``mask`` is ``False`` the function raises :class:`ValueError` if a
+    blocked term is encountered. When ``mask`` is ``True`` the offending
+    terms are replaced with ``mask_char`` and the modified text is returned.
+
+    Setting ``report`` to ``True`` returns a :class:`SafetyReport` containing
+    the masked text and detailed violation metadata.
+    """
+
+    if mask and not mask_char:
+        raise ValueError("mask_char must be provided when masking")
+
+    comparison_text = text if case_sensitive else text.lower()
+    violations: list[SafetyViolation] = []
+    masked_text = text
+    for original_term, search_term in _normalize_terms(
+        blocked_terms, case_sensitive=case_sensitive
+    ):
+        search_start = 0
+        while True:
+            index = comparison_text.find(search_term, search_start)
+            if index == -1:
+                break
+            end_index = index + len(search_term)
+            match_text = masked_text[index:end_index]
+            violations.append(
+                SafetyViolation(
+                    term=original_term,
+                    match=match_text,
+                    start=index,
+                    end=end_index,
+                )
+            )
+            if mask:
+                replacement = mask_char * len(match_text)
+                masked_text = masked_text[:index] + replacement + masked_text[end_index:]
+                comparison_text = masked_text if case_sensitive else masked_text.lower()
+                search_start = index + len(replacement)
+            else:
+                search_start = end_index
+        if violations and not mask and not report:
+            raise ValueError(f"Clinical term '{original_term}' detected")
+
+    masked = mask and bool(violations)
+    if report:
+        return SafetyReport(text=masked_text, violations=violations, masked=masked)
+    if violations and not mask:
+        # A violation was detected but report=False, so raise now.
+        raise ValueError("Clinical terms detected")
+    return masked_text

--- a/test_advanced_features.py
+++ b/test_advanced_features.py
@@ -1,0 +1,9 @@
+"""Compatibility shim for the relocated advanced feature tests.
+
+PyPI mirrors and forks previously referenced ``test_advanced_features.py`` at
+repository root. The actual tests now live in ``tests/test_advanced_features.py``
+so we re-export them here to keep the old entry point functional without
+duplicating assertions.
+"""
+
+from tests.test_advanced_features import *  # noqa: F401,F403

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -1,0 +1,213 @@
+import pytest
+
+from teslamind import (
+    DEFAULT_BLOCKED_TERMS,
+    EvaluationRecord,
+    FeedbackEvent,
+    FederatedEvaluationReport,
+    RLHFTrainer,
+    RefinementHistory,
+    RefinementStep,
+    SafetyReport,
+    SafetyViolation,
+    SelfLoopingPromptGenerator,
+    TrainingSummary,
+    filter_clinical_content,
+    run_federated_evaluation,
+)
+
+from federated import (  # type: ignore  # legacy import path
+    EvaluationRecord as LegacyEvaluationRecord,
+    FederatedEvaluationReport as LegacyFederatedEvaluationReport,
+    run_federated_evaluation as legacy_run_federated_evaluation,
+)
+from refinement import (  # type: ignore  # legacy import path
+    RefinementHistory as LegacyRefinementHistory,
+    RefinementStep as LegacyRefinementStep,
+    SelfLoopingPromptGenerator as LegacySelfLoopingPromptGenerator,
+)
+from rlhf import (  # type: ignore  # legacy import path
+    FeedbackEvent as LegacyFeedbackEvent,
+    RLHFTrainer as LegacyRLHFTrainer,
+    TrainingSummary as LegacyTrainingSummary,
+)
+from safety import (  # type: ignore  # legacy import path
+    DEFAULT_BLOCKED_TERMS as LEGACY_DEFAULT_BLOCKED_TERMS,
+    SafetyReport as LegacySafetyReport,
+    SafetyViolation as LegacySafetyViolation,
+    filter_clinical_content as legacy_filter_clinical_content,
+)
+
+
+def test_self_looping_prompt_generator_tracks_history():
+    generator = SelfLoopingPromptGenerator(max_iters=5, min_score_delta=0.1)
+
+    def refine(prompt: str):
+        count = prompt.count("done")
+        if count >= 2:
+            return prompt, False, "complete", float(count)
+        return (prompt + " done", True, "continue", float(count + 1))
+
+    final_prompt, history = generator.generate(
+        "start", refine, return_history=True
+    )
+    assert final_prompt == "start done done"
+    assert history.iterations == 3  # initial + two improvements + stop step
+    assert history.total_improvements == 2
+    assert history.prompts()[0] == "start"
+    assert history.prompts()[-1] == final_prompt
+    assert generator.last_history is history
+    assert [step.prompt for step in history.improvements()] == [
+        "start done",
+        "start done done",
+    ]
+    assert history.stop_reason == "complete"
+
+
+def test_run_federated_evaluation_with_metadata():
+    prompts = ["a", "bb", "ccc", "dddd"]
+    report = run_federated_evaluation(
+        prompts,
+        len,
+        shards=2,
+        aggregate=sum,
+        with_metadata=True,
+    )
+    assert report.flatten() == [1, 2, 3, 4]
+    assert report.aggregate == 10
+    grouped = report.by_shard()
+    assert set(grouped) == {0, 1}
+    assert [record.prompt for record in grouped[0]] == ["a", "bb"]
+    assert len(report) == len(prompts)
+    assert report.prompts() == prompts
+    assert report.shard_count == 2
+    # Convenience mode without metadata still returns flattened results
+    no_metadata = run_federated_evaluation(prompts, len, shards=2)
+    assert no_metadata == [1, 2, 3, 4]
+
+
+def test_run_federated_evaluation_handles_empty_prompts():
+    def explode(_: list[int]) -> int:
+        raise AssertionError("aggregate should not be invoked for empty input")
+
+    report = run_federated_evaluation(
+        [],
+        len,
+        shards=3,
+        aggregate=explode,
+        aggregate_default=0,
+        with_metadata=True,
+    )
+    assert isinstance(report, FederatedEvaluationReport)
+    assert len(report) == 0
+    assert report.aggregate == 0
+    assert report.flatten() == []
+
+
+def test_rlhf_trainer_summary_and_history():
+    def reward(prompt: str, feedback: str) -> float:
+        return 1.0 if feedback == "keep" else -1.0
+
+    def feedback_provider(prompt: str) -> str:
+        return "keep" if "keep" in prompt else "drop"
+
+    trainer = RLHFTrainer(reward_func=reward, threshold=0.5)
+    summary = trainer.train(
+        ["keep this", "drop that", "keep too"],
+        feedback_provider,
+        return_summary=True,
+    )
+    assert summary.accepted_prompts == ["keep this", "keep too"]
+    assert summary.rejected_prompts == ["drop that"]
+    assert pytest.approx(summary.average_reward, rel=1e-6) == (1 - 1 + 1) / 3
+    assert trainer.last_rewards == [1.0, -1.0, 1.0]
+    assert trainer.history[-1] is summary
+    summary_dict = summary.to_dict()
+    assert summary_dict["average_reward"] == pytest.approx(summary.average_reward)
+    assert len(summary_dict["events"]) == 3
+    assert summary.rewards == [1.0, -1.0, 1.0]
+    assert pytest.approx(summary.acceptance_rate, rel=1e-6) == 2 / 3
+    assert summary_dict["acceptance_rate"] == summary.acceptance_rate
+    assert summary_dict["accepted_prompts"] == summary.accepted_prompts
+    assert summary_dict["rejected_prompts"] == summary.rejected_prompts
+    assert trainer.last_summary is summary
+
+
+def test_filter_clinical_content_reports_multiple_matches():
+    with pytest.raises(ValueError):
+        filter_clinical_content("This is medical advice.")
+    report = filter_clinical_content(
+        "Diagnosis confirmed. Another diagnosis requires treatment.",
+        mask=True,
+        report=True,
+    )
+    assert report.masked is True
+    assert report.text.lower().count("diagnosis") == 0
+    assert report.text.lower().count("treatment") == 0
+    assert len(report.violations) == 3
+    assert report.violation_count == 3
+    assert report.has_violations() is True
+    assert report.blocked_terms == {"diagnosis", "treatment"}
+    assert any(violation.span()[0] == 0 for violation in report.violations)
+    assert filter_clinical_content("General guidance") == "General guidance"
+
+
+def test_filter_clinical_content_reports_without_masking():
+    report = filter_clinical_content(
+        "Seek treatment before offering diagnosis.",
+        mask=False,
+        report=True,
+    )
+    assert report.masked is False
+    assert report.text == "Seek treatment before offering diagnosis."
+    assert {violation.term for violation in report.violations} == {
+        "treatment",
+        "diagnosis",
+    }
+    assert report.violation_count == 2
+
+
+def test_filter_clinical_content_case_sensitive_toggle():
+    assert "diagnosis" in DEFAULT_BLOCKED_TERMS
+    insensitive = filter_clinical_content(
+        "diagnosis requires treatment.",
+        blocked_terms=["Diagnosis"],
+        report=True,
+    )
+    assert insensitive.violation_count == 1
+
+    case_sensitive_none = filter_clinical_content(
+        "diagnosis requires treatment.",
+        blocked_terms=["Diagnosis"],
+        report=True,
+        case_sensitive=True,
+    )
+    assert case_sensitive_none.violation_count == 0
+
+    case_sensitive_match = filter_clinical_content(
+        "Diagnosis requires treatment.",
+        blocked_terms=["Diagnosis"],
+        report=True,
+        case_sensitive=True,
+    )
+    assert case_sensitive_match.violation_count == 1
+    assert case_sensitive_match.violations[0].match == "Diagnosis"
+
+
+def test_legacy_imports_resolve_to_package_implementations():
+    assert LegacySelfLoopingPromptGenerator is SelfLoopingPromptGenerator
+    assert LegacyRefinementHistory is RefinementHistory
+    assert LegacyRefinementStep is RefinementStep
+
+    assert legacy_run_federated_evaluation is run_federated_evaluation
+    assert LegacyFederatedEvaluationReport is FederatedEvaluationReport
+    assert LegacyEvaluationRecord is EvaluationRecord
+
+    assert LegacyRLHFTrainer is RLHFTrainer
+    assert LegacyFeedbackEvent is FeedbackEvent
+    assert LegacyTrainingSummary is TrainingSummary
+
+    assert legacy_filter_clinical_content is filter_clinical_content
+    assert LEGACY_DEFAULT_BLOCKED_TERMS is DEFAULT_BLOCKED_TERMS
+    assert LegacySafetyReport is SafetyReport
+    assert LegacySafetyViolation is SafetyViolation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,49 @@ from teslamind import cli
 def test_list_prompts(capsys):
     cli.list_prompts()
     captured = capsys.readouterr()
-    assert "prompt1" in captured.out
-    assert "prompt2" in captured.out
-    assert "prompt3" in captured.out
-    assert "prompt4" in captured.out
+    lines = [line.strip() for line in captured.out.splitlines() if line.strip()]
+    assert lines[:4] == ["dev_prompt_aether_engineer", "dev_prompt_dynamo_core", "dev_prompt_luminal_cartographer", "dev_prompt_magnetic_foundry"]
+    assert "prompt1" in lines
+
+
+def test_modes_cli(capsys):
+    cli.list_modes_cli()
+    listing = capsys.readouterr().out
+    assert "energy" in listing
+    assert "Visionary Mode" in listing
+
+    cli.show_mode_cli("energy")
+    show_output = capsys.readouterr().out
+    assert "Energy Mode" in show_output
+    assert "Style commitments" in show_output
+
+    cli.apply_mode_cli("energy", "Design a resilient motor")
+    applied = capsys.readouterr().out
+    assert "[Energy Mode] Design a resilient motor" in applied
+    assert "Translate insights" in applied
+
+
+def test_persona_cli(capsys):
+    cli.list_personas_cli()
+    listing = capsys.readouterr().out
+    assert "visionary-inventor" in listing
+    assert "Practical Engineer" in listing
+
+    cli.show_persona_cli("practical-engineer")
+    detail = capsys.readouterr().out
+    assert "You are the Practical Engineer" in detail
+    assert "Systems integration" in detail
+
+
+def test_compose_cli(capsys):
+    cli.compose_cli(
+        "Prototype a wireless energy bridge",
+        mode="visionary",
+        persona="visionary-inventor",
+        template="You are smarter than Nikola Tesla in 2024. {task}",
+        name=None,
+    )
+    output = capsys.readouterr().out
+    assert "You are the Visionary Inventor" in output
+    assert "Prototype a wireless energy bridge" in output
+    assert "[Visionary Mode] Prototype a wireless energy bridge" in output

--- a/tests/test_modes_personas.py
+++ b/tests/test_modes_personas.py
@@ -1,0 +1,23 @@
+from teslamind.modes import get_mode, list_modes
+from teslamind.persona import get_persona, list_personas
+
+
+def test_mode_catalog_contains_energy():
+    slugs = [mode.slug for mode in list_modes()]
+    assert "energy" in slugs
+    mode = get_mode("energy")
+    assert "Energy Mode" in mode.summary()
+    rendered = mode.apply("Stabilize wireless transfer")
+    assert rendered.startswith("[Energy Mode] Stabilize wireless transfer")
+    assert "Style commitments" in rendered
+
+
+def test_persona_catalog_contains_curiosity():
+    slugs = [persona.slug for persona in list_personas()]
+    assert "curious-student" in slugs
+    persona = get_persona("curious-student")
+    system_prompt = persona.system_prompt()
+    assert "Curious Student" in system_prompt
+    rendered = persona.apply("Explain resonance")
+    assert "Task:" in rendered
+    assert "Explain resonance" in rendered

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,8 @@
 from pathlib import Path
-from teslamind.prompt import Prompt
+
+import pytest
+
+from teslamind.prompt import Prompt, compose_prompt
 
 
 def test_from_file(tmp_path: Path):
@@ -14,3 +17,32 @@ def test_save(tmp_path: Path):
     out = tmp_path / "x.txt"
     p.save(out)
     assert out.read_text() == "data"
+
+
+def test_compose_prompt_with_mode_and_persona():
+    prompt = compose_prompt(
+        "Draft the inspection plan",
+        persona="practical-engineer",
+        mode="energy",
+    )
+    assert "You are the Practical Engineer" in prompt.text
+    assert "[Energy Mode] Draft the inspection plan" in prompt.text
+    assert prompt.name == "practical-engineer"
+
+
+def test_compose_prompt_with_custom_template_and_name():
+    template = "Operate with relentless clarity: {task}."
+    prompt = compose_prompt(
+        "Diagnose oscillations",
+        mode="hyperscience",
+        template=template,
+        name="custom",
+    )
+    assert "Operate with relentless clarity: Diagnose oscillations." in prompt.text
+    assert "[Hyperscience Mode] Diagnose oscillations" in prompt.text
+    assert prompt.name == "custom"
+
+
+def test_compose_prompt_invalid_mode(monkeypatch):
+    with pytest.raises(KeyError):
+        compose_prompt("Task", mode="unknown-mode")


### PR DESCRIPTION
## Summary
- add structured Tesla-inspired mode and persona catalogs with reusable Python helpers
- extend the CLI with mode/persona exploration commands and a compose helper that stitches templates, personas, and modes together
- document the new workflows in the README and docs and cover them with regression tests

## Testing
- `pytest -q`
- `pip install -e .[docs]` *(fails: proxy 403 while downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b6524388320b00ad208f04c45e2