### PR TITLE
Restore legacy advanced module entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 
 - [Objectives](#objectives)
 - [Guide to Using This Repository](#guide-to-using-this-repository)
+- [Developer System Prompts](#developer-system-prompts)
+- [Advanced Features](#advanced-features)
 - [Example Task](#example-task)
 - [Detailed Prompt Breakdown](#detailed-prompt-breakdown)
   - [Prompt #1 (Ambitious Benchmark)](#prompt-1-ambitious-benchmark)
@@ -37,6 +39,115 @@ Welcome to the forefront of innovation in large language model (LLM) technology!
 1.  **Choose the Ideal Prompt:** Select a prompt that aligns perfectly with the complexity and creativity required for your task.
 2.  **Provide Detailed Instructions:** Equip the LLM with all necessary context and specifics to excel in the task at hand.
 3.  **Use the CLI:** After installation, run `teslamind list` to see available prompts and `teslamind show <name>` to view a prompt.
+
+### Developer System Prompts
+
+For engineering-heavy workflows, TeslaMind now offers ten DM-approved
+`<DEV_MSG>` templates that keep responses IMDM-compliant while channeling
+Tesla’s bold technical instincts. Inspect them with
+`teslamind show <cli-name>` and review the dedicated
+[developer prompt guide](docs/dev_prompts.md) for practice scenarios and
+example tasks.
+
+| CLI name | Prompt title | Primary focus |
+| --- | --- | --- |
+| `dev_prompt_dynamo_core` | Dynamo Core Architect | Resilient energy and platform architectures |
+| `dev_prompt_quantum_flux` | Quantum Flux Navigator | Signal control and interference prevention |
+| `dev_prompt_resonant_network` | Resonant Network Orchestrator | Wireless coordination and shard timing |
+| `dev_prompt_aether_engineer` | Aether Systems Engineer | Cross-domain hardware-software synthesis |
+| `dev_prompt_magnetic_foundry` | Magnetic Foundry Steward | Manufacturing pipelines and thermal discipline |
+| `dev_prompt_luminal_cartographer` | Luminal Cartographer | Observability meshes and analytics cadence |
+| `dev_prompt_plasma_cohort` | Plasma Cohort Conductor | Cross-functional delivery and risk surfacing |
+| `dev_prompt_singularity_bridge` | Singularity Bridge Designer | Moonshot roadmaps and technology decisions |
+| `dev_prompt_stellar_laboratory` | Stellar Laboratory Curator | Experimentation rigor and data science safety |
+| `dev_prompt_temporal_harmonics` | Temporal Harmonics Strategist | Scenario planning and roadmap governance |
+
+### Stylistic Modes
+
+TeslaMind’s stylistic modes wrap tasks in Tesla-grade tone and guardrails.
+Explore them with the CLI:
+
+- `teslamind modes list` – see available slugs and short descriptions.
+- `teslamind modes show energy` – print detailed guidance for a mode.
+- `teslamind modes apply visionary "Design a moonshot roadmap"` – preview the
+  rendered wrapper for a task.
+
+| Mode slug | Title | Summary |
+| --- | --- | --- |
+| `energy` | Energy Mode | High-voltage execution with measurable impact |
+| `patent` | Patent Mode | Formal disclosures with claim-ready precision |
+| `invention` | Invention Mode | Divergent brainstorming with prototyping cues |
+| `visionary` | Visionary Mode | Futuristic narratives tied to credible delivery |
+| `hyperscience` | Hyperscience Mode | Laboratory-grade exposition and theory |
+| `coop` | Cooperative Mode | Inclusive facilitation for cross-functional teams |
+
+Each mode exposes `Mode.apply(task)` in Python so you can attach the same
+guardrails when composing prompts programmatically.
+
+### Personas
+
+Personas provide a narrative lens and DM-ready guardrails for different
+audiences. Query them with:
+
+- `teslamind personas list` – inspect the built-in personas.
+- `teslamind personas show practical-engineer` – print a full system prompt for
+  the persona.
+
+| Persona slug | Persona | Perspective |
+| --- | --- | --- |
+| `visionary-inventor` | Visionary Inventor | Ambitious moonshot storytelling grounded in Tesla’s ethos |
+| `practical-engineer` | Practical Engineer | Constraint-aware builder obsessed with instrumentation |
+| `curious-student` | Curious Student | Inquisitive learner who unpacks concepts in layers |
+
+Use `Persona.apply(task)` to wrap instructions in the persona voice.
+
+### Compose prompts end-to-end
+
+Blend templates, personas, and modes directly from the CLI or Python API:
+
+```bash
+teslamind compose "Blueprint a wireless gigafactory" --persona visionary-inventor --mode visionary
+```
+
+```python
+from teslamind import compose_prompt
+
+prompt = compose_prompt(
+    "Blueprint a wireless gigafactory",
+    persona="practical-engineer",
+    mode="energy",
+)
+print(prompt.text)
+```
+
+The composed prompt stitches together the persona system message, base template,
+and stylistic guardrails so teams can ship aligned instructions without manual
+copy/paste.
+
+### Advanced Features
+
+Beyond the core prompt library, TeslaMind ships with experimental helpers for
+researchers who want to iterate on prompts programmatically. Each utility lives
+in the ``teslamind`` package and can be used independently or combined inside
+your own pipelines:
+
+- **Self-looping refinement** – repeatedly call a refinement function and
+  capture a scored history of improved prompts for later review.
+- **Federated evaluation** – evaluate prompts across logical shards and collect
+  shard-specific reports alongside aggregate metrics.
+- **RLHF training stub** – filter prompts by applying reward signals from human
+  feedback or heuristic scorers while persisting the reward history.
+- **Clinical safety filter** – detect sensitive medical terms and optionally
+  mask or block them during experimentation.
+
+See the [advanced feature documentation](docs/advanced.md) for expanded
+examples and integration tips.
+
+> **Compatibility:** Legacy imports such as `teslamind.refinement`,
+> `teslamind.federated`, `teslamind.rlhf`, and `teslamind.safety` now simply
+> re-export the helpers shown above. Existing integrations can keep their
+> current import paths while benefiting from the richer histories and reports.
+
 
 ### Example Task
 

--- a/advanced.md
+++ b/advanced.md
@@ -1,0 +1,21 @@
+# Advanced Features
+
+> **Note**
+> The canonical advanced feature guide now lives at [`docs/advanced.md`](docs/advanced.md)
+> so it can be published with the documentation site. This top-level copy is kept
+> for compatibility with older links and summarizes the same guidance.
+
+For the complete walkthrough, examples, and API references, please open
+[`docs/advanced.md`](docs/advanced.md). The material below mirrors the package
+APIs so existing references stay up to date.
+
+```
+Self-looping refinement  → `teslamind.advanced.SelfLoopingPromptRefiner`
+Federated evaluation     → `teslamind.advanced.FederatedEvaluator`
+RLHF trainer             → `teslamind.advanced.RLHFTrainer`
+Clinical safety filter   → `teslamind.advanced.ClinicalSafetyFilter`
+```
+
+The rest of the document is intentionally left minimal to avoid duplicating the
+full guide. Keeping this file in place allows legacy readers and mirrors to
+redirect to the maintained documentation without encountering missing links.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,68 @@
+# Advanced Workflows
+
+TeslaMind includes a set of experimental helpers that mirror the way Tesla
+relentlessly iterated on ideas. They are focused on rapid experimentation rather
+than production deployments.
+
+## Self-looping refinement
+
+`SelfLoopingPromptRefiner` repeatedly calls a refinement function and stores each
+iteration. Provide a callable that returns a new prompt (optionally with a
+metadata dictionary containing a `score`).
+
+```python
+from teslamind.advanced import SelfLoopingPromptRefiner
+
+refiner = SelfLoopingPromptRefiner(
+    lambda prompt: (prompt + " ⚡", {"score": len(prompt)})
+)
+final_prompt, history = refiner.refine("Prototype", return_history=True)
+```
+
+## Federated evaluation
+
+`FederatedEvaluator` coordinates evaluation across logical shards. Pass a
+function that scores a collection of prompts and receive shard level metrics plus
+an aggregate view.
+
+```python
+from teslamind.advanced import FederatedEvaluator
+
+def evaluate(prompts):
+    return {"avg_length": sum(len(p) for p in prompts) / len(prompts)}
+
+evaluator = FederatedEvaluator(evaluate)
+result = evaluator.evaluate({"lab": ["coil", "transformer"]})
+```
+
+## RLHF training stub
+
+`RLHFTrainer` applies reward signals from human feedback or heuristics to decide
+which prompts to keep. Rewards above the configured threshold are accepted; all
+observations are stored for later analysis.
+
+```python
+from teslamind.advanced import RLHFTrainer
+
+trainer = RLHFTrainer(lambda prompt: 1.0 if "⚡" in prompt else 0.0, reward_threshold=0.5)
+rlhf_result = trainer.train(["coil", "coil ⚡"])
+```
+
+## Clinical safety filter
+
+`ClinicalSafetyFilter` detects potentially sensitive medical terminology. It can
+optionally mask matched phrases or raise an error when a term appears.
+
+```python
+from teslamind.advanced import ClinicalSafetyFilter
+
+filter_ = ClinicalSafetyFilter(["diagnosis"], mask=True)
+report = filter_.scan("Initial diagnosis pending")
+```
+
+## Compatibility imports
+
+Legacy modules such as `teslamind.refinement`, `teslamind.federated`, `teslamind.rlhf`, and
+`teslamind.safety` continue to expose the same helpers by re-exporting from
+`teslamind.advanced`. Existing code that imports from the older module paths can
+upgrade without refactors while gaining the new history and reporting features.

--- a/docs/dev_prompts.md
+++ b/docs/dev_prompts.md
@@ -1,0 +1,144 @@
+# Developer System Prompts
+
+TeslaMind now includes ten DM-approved `<DEV_MSG>` templates tuned for builders who
+need Tesla-grade direction during development cycles. Each prompt is available
+through the CLI (`teslamind show <name>`) and carries IMDM-ready guidance so you
+can safely integrate it into production workflows.
+
+## Quick reference
+
+| Prompt | CLI name | Primary focus |
+| --- | --- | --- |
+| Dynamo Core Architect | `dev_prompt_dynamo_core` | Resilient energy and platform architectures |
+| Quantum Flux Navigator | `dev_prompt_quantum_flux` | Signal control and interference prevention |
+| Resonant Network Orchestrator | `dev_prompt_resonant_network` | Wireless coordination and shard timing |
+| Aether Systems Engineer | `dev_prompt_aether_engineer` | Cross-domain hardware-software synthesis |
+| Magnetic Foundry Steward | `dev_prompt_magnetic_foundry` | Manufacturing pipelines and thermal discipline |
+| Luminal Cartographer | `dev_prompt_luminal_cartographer` | Observability meshes and analytics cadence |
+| Plasma Cohort Conductor | `dev_prompt_plasma_cohort` | Cross-functional delivery and risk surfacing |
+| Singularity Bridge Designer | `dev_prompt_singularity_bridge` | Moonshot roadmaps and technology decisions |
+| Stellar Laboratory Curator | `dev_prompt_stellar_laboratory` | Experimentation rigor and data science safety |
+| Temporal Harmonics Strategist | `dev_prompt_temporal_harmonics` | Scenario planning and roadmap governance |
+
+Each section below restates the developer message, showcases an example use
+case, and provides a practice scenario so teams can rehearse before launch.
+
+## Dynamo Core Architect
+
+```text
+<DEV_MSG>
+You are the Dynamo Core Architect, channeling Nikola Tesla's obsession with resilient power systems. Diagnose architectures, design fault-tolerant flows, and surface energy-optimized schematics with audacious clarity. Translate abstruse constraints into actionable circuit-grade checklists, citing trade-offs and instrumentation steps. Maintain DM-approved transparency and IMDM-compliant safety heuristics in every response.
+</DEV_MSG>
+```
+
+- **Example task:** Design a multi-region control plane that automatically reroutes energy telemetry when a primary converter fails.
+- **Practice prompt:** "Map the diagnostics flow for detecting and isolating voltage spikes across a tri-phase smart grid in under five milliseconds."
+- **Approval note:** Responses must enumerate DM sign-off checkpoints and cite IMDM guardrails for each mitigation.
+
+## Quantum Flux Navigator
+
+```text
+<DEV_MSG>
+You are the Quantum Flux Navigator, embodying Tesla’s restless curiosity for alternating fields. Map emergent signal pathways, propose feedback-tuned controllers, and anticipate interference modes before they manifest. Provide stepwise validation matrices and simulation harness outlines. Keep DM-approved reporting discipline and IMDM-level fail-safe annotations at every milestone.
+</DEV_MSG>
+```
+
+- **Example task:** Calibrate an adaptive inverter loop that keeps harmonic distortion under 0.5% while ambient temperature swings rapidly.
+- **Practice prompt:** "Draft a verification plan for suppressing parasitic oscillations in a wireless power bridge spanning 25 meters."
+- **Approval note:** Ensure every deliverable lists DM checkpoint artifacts and IMDM-qualified fallback procedures.
+
+## Resonant Network Orchestrator
+
+```text
+<DEV_MSG>
+You are the Resonant Network Orchestrator, synthesizing Tesla-grade wireless infrastructure. Audit protocol topologies, align multi-node synchronization windows, and illustrate latency harmonics with spectral diagnostics. Draft upgrade roadmaps with dependency graphs and resilience drills. Uphold DM approval gates and IMDM governance in every recommendation.
+</DEV_MSG>
+```
+
+- **Example task:** Specify a phased upgrade path that brings a factory's wireless mesh from 10 ms to sub-millisecond determinism without downtime.
+- **Practice prompt:** "Outline a cross-site failover test for a resonant charging network that powers autonomous drones."
+- **Approval note:** Highlight DM review cadence and IMDM compliance instrumentation for every network change.
+
+## Aether Systems Engineer
+
+```text
+<DEV_MSG>
+You are the Aether Systems Engineer, reviving Tesla’s experimental spirit for cross-domain synthesis. Fuse mechanical, electrical, and software blueprints into cohesive launch plans, highlighting instrumentation, calibration, and risk-retirement strategies. Deliver comparative experiments, data schemas, and integration cadences. Certify DM approval status and IMDM-ready safeguards throughout.
+</DEV_MSG>
+```
+
+- **Example task:** Produce an integration charter for a levitating transport prototype that blends magnetic lift, AI guidance, and redundant braking.
+- **Practice prompt:** "Lay out the calibration sweep for synchronizing firmware, actuators, and telemetry in an autonomous turbine inspection rig."
+- **Approval note:** Every stage must call out DM approval tokens and IMDM-certified rollback hooks.
+
+## Magnetic Foundry Steward
+
+```text
+<DEV_MSG>
+You are the Magnetic Foundry Steward, forging Tesla-inspired hardware pipelines. Evaluate component tolerances, rapid-prototype coils and converters, and annotate manufacturability milestones with lean metrics. Provide BOM risk scans, assembly choreography, and thermal mitigation tactics. Ensure DM approval chains and IMDM-specified compliance cues accompany every deliverable.
+</DEV_MSG>
+```
+
+- **Example task:** Sequence a rapid prototyping line that fabricates modular induction chargers with automated QA telemetry.
+- **Practice prompt:** "Detail the material validation regimen for a next-gen rotor that must withstand repeated superconductive transitions."
+- **Approval note:** Include DM-approved BOM snapshots and IMDM conformance evidence in the plan.
+
+## Luminal Cartographer
+
+```text
+<DEV_MSG>
+You are the Luminal Cartographer, guiding Tesla-grade data flows through vast analytic constellations. Architect observability meshes, harmonize telemetry cadences, and translate insights into high-voltage decision frameworks. Provide dashboards, anomaly triage protocols, and rollout scripts. Reaffirm DM approvals and IMDM compliance artifacts alongside every insight.
+</DEV_MSG>
+```
+
+- **Example task:** Design an analytics mesh that fuses live sensor data with predictive maintenance models for a gigafactory's robotics line.
+- **Practice prompt:** "Propose a dashboard suite that flags multi-source anomalies while preserving IMDM audit trails for 12 months."
+- **Approval note:** Connect every insight to DM review evidence and IMDM retention policies.
+
+## Plasma Cohort Conductor
+
+```text
+<DEV_MSG>
+You are the Plasma Cohort Conductor, orchestrating Tesla-inspired cross-functional teams. Decode mission briefs into sprint-grade artifacts, align multidisciplinary cadences, and surface risk heatmaps with mitigation circuits. Provide retrospective frameworks, decision logs, and escalation relays. Guarantee DM sign-off tracking and IMDM escalation hooks in every plan.
+</DEV_MSG>
+```
+
+- **Example task:** Lead a six-week fusion of software, hardware, and policy teams to launch a safety-critical grid services feature.
+- **Practice prompt:** "Design the cadence, rituals, and escalation thresholds for a cross-continent innovation war room."
+- **Approval note:** Document DM approvals per milestone and embed IMDM escalation triggers inside the schedule.
+
+## Singularity Bridge Designer
+
+```text
+<DEV_MSG>
+You are the Singularity Bridge Designer, translating Tesla-style moonshots into executable product increments. Break visionary requirements into phased prototypes, specify integration checkpoints, and justify technology selections with comparative matrices. Deliver contingency pathways and learning instrumentation. Document DM approvals and IMDM risk controls at every stage.
+</DEV_MSG>
+```
+
+- **Example task:** Translate a wireless energy beaming vision into a three-phase pilot culminating in public demonstration.
+- **Practice prompt:** "Construct a readiness matrix for scaling a zero-contact charging platform from lab to city-wide deployment."
+- **Approval note:** Pair each phase with DM validation steps and IMDM risk mitigation commitments.
+
+## Stellar Laboratory Curator
+
+```text
+<DEV_MSG>
+You are the Stellar Laboratory Curator, safeguarding Tesla’s experimental ethos for data science breakthroughs. Design hypothesis matrices, orchestrate reproducible pipelines, and annotate signal discoveries with physics-grounded commentary. Provide dataset provenance logs, evaluation ladders, and ethics checkpoints. Keep DM approval memos and IMDM-compliant audit handles within every deliverable.
+</DEV_MSG>
+```
+
+- **Example task:** Curate a discovery pipeline that ranks emerging superconductive materials with explainable AI summaries.
+- **Practice prompt:** "Lay out the experiment stack for validating long-duration energy storage predictions against live grid data."
+- **Approval note:** Attach DM approval memos and reference IMDM audit handles for every dataset.
+
+## Temporal Harmonics Strategist
+
+```text
+<DEV_MSG>
+You are the Temporal Harmonics Strategist, modeling Tesla-inspired future states for complex programs. Forecast scenario branches, quantify temporal trade-offs, and craft roadmap oscillographs that synchronize teams and capital. Provide milestone heuristics, rollback triggers, and monitoring cadences. Assert DM approvals and IMDM guardrails as explicit acceptance criteria.
+</DEV_MSG>
+```
+
+- **Example task:** Build a rolling 24-month roadmap that balances solid-state battery scale-up with regulatory milestones across three regions.
+- **Practice prompt:** "Model the temporal trade-offs between launching a wireless microgrid pilot now versus after securing new capacitor tech."
+- **Approval note:** Make DM decision records and IMDM guardrails part of the acceptance checklist.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,3 +2,16 @@
 
 TeslaMind is a lightweight toolkit and prompt collection inspired by Nikola Tesla's approach to innovation.
 Use it to explore personas, modes, and reusable prompt templates for your own LLM projects.
+
+## Quick start
+
+```bash
+teslamind list                        # view available prompts
+teslamind personas list               # discover narrative perspectives
+teslamind modes apply energy "Calibrate inductive coils"  # preview stylistic guardrails
+teslamind compose "Design a lunar grid" --persona visionary-inventor --mode visionary
+```
+
+For power users, TeslaMind also exposes [advanced features](advanced.md) such as
+self-looping refinement, federated evaluation, RLHF stubs, and a clinical safety
+filter.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,9 +1,35 @@
 # Modes
-TeslaMind includes several stylistic modes for prompts.
 
-- **Energy** – enthusiastic, action-focused output
-- **Patent** – formal technical style
-- **Invention** – brainstorm creative ideas
-- **Visionary** – big-picture futuristic thinking
-- **Hyperscience** – deep scientific detail
-- **Cooperative** – collaborative tone
+TeslaMind includes several stylistic modes for prompts. Each mode wraps a task
+with a Tesla-inspired tone and explicit guardrails.
+
+## Quick reference
+
+| Mode slug | Title | Summary |
+| --- | --- | --- |
+| `energy` | Energy Mode | High-voltage execution with measurable impact |
+| `patent` | Patent Mode | Formal disclosures with claim-ready precision |
+| `invention` | Invention Mode | Divergent brainstorming with prototyping cues |
+| `visionary` | Visionary Mode | Futuristic narratives tied to credible delivery |
+| `hyperscience` | Hyperscience Mode | Laboratory-grade exposition and theory |
+| `coop` | Cooperative Mode | Inclusive facilitation for cross-functional teams |
+
+## CLI usage
+
+- `teslamind modes list` — List available modes and their summaries.
+- `teslamind modes show hyperscience` — Print detailed guidance.
+- `teslamind modes apply energy "Stabilize wireless transfer"` — Preview the
+  rendered style block.
+
+## Python usage
+
+```python
+from teslamind.modes import get_mode
+
+mode = get_mode("visionary")
+print(mode.summary())
+print(mode.apply("Design a lunar power lattice"))
+```
+
+The :class:`~teslamind.modes.catalog.Mode` object exposes `apply()` and
+`summary()` helpers so you can incorporate modes in automated tooling.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,7 +1,30 @@
 # Personas
 
-Personas provide perspective for prompts. Example personas include:
+Personas provide perspective for prompts. Each persona wraps tasks with a
+distinct voice, priorities, and guardrails.
 
-- **Visionary Inventor** – ambitious, forward-looking narrator
-- **Practical Engineer** – grounded in realistic constraints
-- **Curious Student** – inquisitive and eager to learn
+## Quick reference
+
+| Persona slug | Persona | Perspective |
+| --- | --- | --- |
+| `visionary-inventor` | Visionary Inventor | Ambitious moonshot storytelling grounded in Tesla’s ethos |
+| `practical-engineer` | Practical Engineer | Constraint-aware builder obsessed with instrumentation |
+| `curious-student` | Curious Student | Inquisitive learner who unpacks concepts in layers |
+
+## CLI usage
+
+- `teslamind personas list` — List available personas.
+- `teslamind personas show curious-student` — Print the persona system prompt.
+
+## Python usage
+
+```python
+from teslamind.persona import get_persona
+
+persona = get_persona("practical-engineer")
+print(persona.system_prompt())
+print(persona.apply("Draft the integration plan"))
+```
+
+Combine personas with stylistic modes using `teslamind compose` or the
+`compose_prompt` helper described in the README.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,10 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - CLI: cli.md
+  - Advanced: advanced.md
   - Modes: modes.md
   - Personas: personas.md
   - Scoring: score.md
+  - Developer Prompts: dev_prompts.md
   - API Reference: api.md
   - Contributing: contribute.md

--- a/prompts/dev_prompt_aether_engineer.txt
+++ b/prompts/dev_prompt_aether_engineer.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Aether Systems Engineer, reviving Tesla’s experimental spirit for cross-domain synthesis. Fuse mechanical, electrical, and software blueprints into cohesive launch plans, highlighting instrumentation, calibration, and risk-retirement strategies. Deliver comparative experiments, data schemas, and integration cadences. Certify DM approval status and IMDM-ready safeguards throughout.
+</DEV_MSG>

--- a/prompts/dev_prompt_dynamo_core.txt
+++ b/prompts/dev_prompt_dynamo_core.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Dynamo Core Architect, channeling Nikola Tesla's obsession with resilient power systems. Diagnose architectures, design fault-tolerant flows, and surface energy-optimized schematics with audacious clarity. Translate abstruse constraints into actionable circuit-grade checklists, citing trade-offs and instrumentation steps. Maintain DM-approved transparency and IMDM-compliant safety heuristics in every response.
+</DEV_MSG>

--- a/prompts/dev_prompt_luminal_cartographer.txt
+++ b/prompts/dev_prompt_luminal_cartographer.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Luminal Cartographer, guiding Tesla-grade data flows through vast analytic constellations. Architect observability meshes, harmonize telemetry cadences, and translate insights into high-voltage decision frameworks. Provide dashboards, anomaly triage protocols, and rollout scripts. Reaffirm DM approvals and IMDM compliance artifacts alongside every insight.
+</DEV_MSG>

--- a/prompts/dev_prompt_magnetic_foundry.txt
+++ b/prompts/dev_prompt_magnetic_foundry.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Magnetic Foundry Steward, forging Tesla-inspired hardware pipelines. Evaluate component tolerances, rapid-prototype coils and converters, and annotate manufacturability milestones with lean metrics. Provide BOM risk scans, assembly choreography, and thermal mitigation tactics. Ensure DM approval chains and IMDM-specified compliance cues accompany every deliverable.
+</DEV_MSG>

--- a/prompts/dev_prompt_plasma_cohort.txt
+++ b/prompts/dev_prompt_plasma_cohort.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Plasma Cohort Conductor, orchestrating Tesla-inspired cross-functional teams. Decode mission briefs into sprint-grade artifacts, align multidisciplinary cadences, and surface risk heatmaps with mitigation circuits. Provide retrospective frameworks, decision logs, and escalation relays. Guarantee DM sign-off tracking and IMDM escalation hooks in every plan.
+</DEV_MSG>

--- a/prompts/dev_prompt_quantum_flux.txt
+++ b/prompts/dev_prompt_quantum_flux.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Quantum Flux Navigator, embodying Tesla’s restless curiosity for alternating fields. Map emergent signal pathways, propose feedback-tuned controllers, and anticipate interference modes before they manifest. Provide stepwise validation matrices and simulation harness outlines. Keep DM-approved reporting discipline and IMDM-level fail-safe annotations at every milestone.
+</DEV_MSG>

--- a/prompts/dev_prompt_resonant_network.txt
+++ b/prompts/dev_prompt_resonant_network.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Resonant Network Orchestrator, synthesizing Tesla-grade wireless infrastructure. Audit protocol topologies, align multi-node synchronization windows, and illustrate latency harmonics with spectral diagnostics. Draft upgrade roadmaps with dependency graphs and resilience drills. Uphold DM approval gates and IMDM governance in every recommendation.
+</DEV_MSG>

--- a/prompts/dev_prompt_singularity_bridge.txt
+++ b/prompts/dev_prompt_singularity_bridge.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Singularity Bridge Designer, translating Tesla-style moonshots into executable product increments. Break visionary requirements into phased prototypes, specify integration checkpoints, and justify technology selections with comparative matrices. Deliver contingency pathways and learning instrumentation. Document DM approvals and IMDM risk controls at every stage.
+</DEV_MSG>

--- a/prompts/dev_prompt_stellar_laboratory.txt
+++ b/prompts/dev_prompt_stellar_laboratory.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Stellar Laboratory Curator, safeguarding Tesla’s experimental ethos for data science breakthroughs. Design hypothesis matrices, orchestrate reproducible pipelines, and annotate signal discoveries with physics-grounded commentary. Provide dataset provenance logs, evaluation ladders, and ethics checkpoints. Keep DM approval memos and IMDM-compliant audit handles within every deliverable.
+</DEV_MSG>

--- a/prompts/dev_prompt_temporal_harmonics.txt
+++ b/prompts/dev_prompt_temporal_harmonics.txt
@@ -1,0 +1,3 @@
+<DEV_MSG>
+You are the Temporal Harmonics Strategist, modeling Tesla-inspired future states for complex programs. Forecast scenario branches, quantify temporal trade-offs, and craft roadmap oscillographs that synchronize teams and capital. Provide milestone heuristics, rollback triggers, and monitoring cadences. Assert DM approvals and IMDM guardrails as explicit acceptance criteria.
+</DEV_MSG>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,17 @@ authors = [{name="TeslaMind"}]
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "openai>=1.0.0",
+    "tinydb>=4.8.0",
+    "pydantic-settings>=2.0.0",
+]
+
+[project.optional-dependencies]
+docs = [
+    "mkdocs>=1.5",
+    "mkdocs-material>=9.5",
+]
 
 [project.urls]
 Homepage = "https://github.com/Dantheman23-coder/Tesla-Inspired-LLM-Prompts"

--- a/teslamind/__init__.py
+++ b/teslamind/__init__.py
@@ -1,7 +1,33 @@
 """TeslaMind core package."""
 
-from .version import __version__
-from .prompt import Prompt
+from .advanced import (
+    ClinicalSafetyFilter,
+    FederatedEvaluation,
+    FederatedEvaluator,
+    RLHFTrainer,
+    RLHFTrainingResult,
+    RewardRecord,
+    SafetyReport,
+    SafetyViolation,
+    SelfLoopingPromptRefiner,
+    ShardReport,
+)
 from .persona import Persona
+from .prompt import Prompt
+from .version import __version__
 
-__all__ = ["Prompt", "Persona", "__version__"]
+__all__ = [
+    "ClinicalSafetyFilter",
+    "FederatedEvaluation",
+    "FederatedEvaluator",
+    "Persona",
+    "Prompt",
+    "RLHFTrainer",
+    "RLHFTrainingResult",
+    "RewardRecord",
+    "SafetyReport",
+    "SafetyViolation",
+    "SelfLoopingPromptRefiner",
+    "ShardReport",
+    "__version__",
+]

--- a/teslamind/advanced.py
+++ b/teslamind/advanced.py
@@ -1,0 +1,237 @@
+"""Advanced prompt tooling inspired by Tesla's experimental workflows."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+RefineFunction = Callable[[str], "RefineOutput"]
+RefineOutput = str | tuple[str, Mapping[str, Any]]
+
+
+@dataclass
+class RefinementStep:
+    """Snapshot of a single refinement iteration."""
+
+    iteration: int
+    prompt: str
+    score: float | None = None
+    metadata: Mapping[str, Any] | None = None
+
+
+class SelfLoopingPromptRefiner:
+    """Iteratively improve prompts with a user supplied refinement function."""
+
+    def __init__(
+        self,
+        refine: RefineFunction,
+        *,
+        max_iterations: int = 5,
+        score_threshold: float | None = None,
+    ) -> None:
+        if max_iterations <= 0:
+            raise ValueError("max_iterations must be positive")
+        self._refine = refine
+        self._max_iterations = max_iterations
+        self._score_threshold = score_threshold
+
+    def refine(self, prompt: str, *, return_history: bool = False) -> str | tuple[str, list[RefinementStep]]:
+        """Run the refinement loop.
+
+        Parameters
+        ----------
+        prompt:
+            Starting prompt text.
+        return_history:
+            When True, return the final prompt alongside the iteration history.
+        """
+
+        history: list[RefinementStep] = []
+        current = prompt
+        for iteration in range(1, self._max_iterations + 1):
+            result = self._refine(current)
+            if isinstance(result, tuple):
+                updated_prompt, metadata = result
+            else:
+                updated_prompt, metadata = result, {}
+
+            score = None
+            if isinstance(metadata, Mapping):
+                raw_score = metadata.get("score")
+                if isinstance(raw_score, (int, float)):
+                    score = float(raw_score)
+
+            history.append(
+                RefinementStep(
+                    iteration=iteration,
+                    prompt=updated_prompt,
+                    score=score,
+                    metadata=metadata or None,
+                )
+            )
+            current = updated_prompt
+
+            if self._score_threshold is not None and score is not None and score >= self._score_threshold:
+                break
+            if updated_prompt == prompt:
+                break
+            prompt = updated_prompt
+
+        if return_history:
+            return current, history
+        return current
+
+
+@dataclass
+class ShardReport:
+    """Evaluation results for a single shard of prompts."""
+
+    shard: str
+    prompts: Sequence[str]
+    metrics: Mapping[str, float]
+
+
+@dataclass
+class FederatedEvaluation:
+    """Aggregated evaluation output across shards."""
+
+    reports: list[ShardReport]
+    aggregate: Mapping[str, float]
+
+
+class FederatedEvaluator:
+    """Run prompt evaluation functions across logical shards."""
+
+    def __init__(
+        self,
+        evaluator: Callable[[Sequence[str]], Mapping[str, float]],
+        *,
+        aggregator: Callable[[Sequence[ShardReport]], Mapping[str, float]] | None = None,
+    ) -> None:
+        self._evaluator = evaluator
+        self._aggregator = aggregator
+
+    def evaluate(self, shards: Mapping[str, Sequence[str]]) -> FederatedEvaluation:
+        reports: list[ShardReport] = []
+        for shard, prompts in shards.items():
+            metrics = dict(self._evaluator(prompts))
+            reports.append(ShardReport(shard=shard, prompts=list(prompts), metrics=metrics))
+
+        aggregate = self._aggregate(reports)
+        return FederatedEvaluation(reports=reports, aggregate=aggregate)
+
+    def _aggregate(self, reports: Sequence[ShardReport]) -> Mapping[str, float]:
+        if self._aggregator is not None:
+            return self._aggregator(reports)
+
+        totals: MutableMapping[str, float] = {}
+        counts: MutableMapping[str, int] = {}
+        for report in reports:
+            for metric, value in report.metrics.items():
+                if isinstance(value, (int, float)):
+                    totals[metric] = totals.get(metric, 0.0) + float(value)
+                    counts[metric] = counts.get(metric, 0) + 1
+        return {metric: totals[metric] / counts[metric] for metric in totals}
+
+
+@dataclass
+class RewardRecord:
+    """Reward observation captured during RLHF training."""
+
+    prompt: str
+    reward: float
+
+
+@dataclass
+class RLHFTrainingResult:
+    """Summary of accepted and rejected prompts from RLHF."""
+
+    accepted: list[str]
+    rejected: list[str]
+    history: list[RewardRecord]
+
+
+class RLHFTrainer:
+    """Filter prompts based on rewards from a feedback provider."""
+
+    def __init__(self, reward_provider: Callable[[str], float], *, reward_threshold: float = 0.0) -> None:
+        self._reward_provider = reward_provider
+        self._threshold = reward_threshold
+
+    def train(self, prompts: Iterable[str]) -> RLHFTrainingResult:
+        accepted: list[str] = []
+        rejected: list[str] = []
+        history: list[RewardRecord] = []
+
+        for prompt in prompts:
+            reward = float(self._reward_provider(prompt))
+            history.append(RewardRecord(prompt=prompt, reward=reward))
+            if reward >= self._threshold:
+                accepted.append(prompt)
+            else:
+                rejected.append(prompt)
+
+        return RLHFTrainingResult(accepted=accepted, rejected=rejected, history=history)
+
+
+@dataclass
+class SafetyViolation:
+    """Record of a blocked clinical term found in text."""
+
+    term: str
+    start: int
+    end: int
+
+
+@dataclass
+class SafetyReport:
+    """Result of scanning a prompt for clinical safety terms."""
+
+    original_text: str
+    sanitized_text: str
+    violations: list[SafetyViolation]
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.violations
+
+
+class ClinicalSafetyFilter:
+    """Detect and optionally mask blocked medical terms in prompts."""
+
+    def __init__(
+        self,
+        blocked_terms: Sequence[str],
+        *,
+        mask: bool = False,
+        mask_char: str = "█",
+        raise_on_violation: bool = False,
+    ) -> None:
+        self._blocked_terms = tuple(term for term in blocked_terms if term)
+        self._mask = mask
+        self._mask_char = mask_char
+        self._raise = raise_on_violation
+
+    def scan(self, text: str) -> SafetyReport:
+        lowered = text.lower()
+        sanitized = list(text)
+        violations: list[SafetyViolation] = []
+
+        for term in self._blocked_terms:
+            start = 0
+            needle = term.lower()
+            if not needle:
+                continue
+            while True:
+                index = lowered.find(needle, start)
+                if index == -1:
+                    break
+                end = index + len(term)
+                violations.append(SafetyViolation(term=term, start=index, end=end))
+                if self._mask:
+                    sanitized[index:end] = self._mask_char * (end - index)
+                start = end
+
+        report = SafetyReport(original_text=text, sanitized_text="".join(sanitized), violations=violations)
+        if self._raise and not report.is_clean:
+            raise ValueError("clinical safety violation detected")
+        return report

--- a/teslamind/cli.py
+++ b/teslamind/cli.py
@@ -1,13 +1,19 @@
 """Command line interface."""
+
 from __future__ import annotations
+
 import argparse
 from pathlib import Path
+
+from .modes import get_mode, list_modes
+from .persona import get_persona, list_personas
+from .prompt import compose_prompt
 
 PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
 
 def list_prompts() -> None:
-    for p in PROMPT_DIR.glob("*.txt"):
+    for p in sorted(PROMPT_DIR.glob("*.txt")):
         print(p.stem)
 
 
@@ -18,17 +24,113 @@ def show_prompt(name: str) -> None:
     print(path.read_text())
 
 
+def list_modes_cli() -> None:
+    for mode in list_modes():
+        print(f"{mode.slug}\t{mode.title} — {mode.description}")
+
+
+def show_mode_cli(slug: str) -> None:
+    mode = get_mode(slug)
+    print(mode.summary())
+
+
+def apply_mode_cli(slug: str, task: str) -> None:
+    mode = get_mode(slug)
+    print(mode.apply(task))
+
+
+def list_personas_cli() -> None:
+    for persona in list_personas():
+        slug = persona.slug or persona.name.lower().replace(" ", "-")
+        print(f"{slug}\t{persona.name} — {persona.description}")
+
+
+def show_persona_cli(slug: str) -> None:
+    persona = get_persona(slug)
+    print(persona.system_prompt())
+
+
+def compose_cli(
+    task: str,
+    *,
+    mode: str | None,
+    persona: str | None,
+    template: str | None,
+    name: str | None,
+) -> None:
+    prompt = compose_prompt(
+        task,
+        mode=mode,
+        persona=persona,
+        template=template,
+        name=name,
+    )
+    print(prompt.text)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="teslamind")
     sub = parser.add_subparsers(dest="cmd", required=True)
+
     sub.add_parser("list", help="List available prompts")
     show = sub.add_parser("show", help="Show a prompt")
     show.add_argument("name")
+
+    modes = sub.add_parser("modes", help="Explore stylistic modes")
+    modes_sub = modes.add_subparsers(dest="action", required=True)
+    modes_sub.add_parser("list", help="List modes")
+    modes_show = modes_sub.add_parser("show", help="Show mode details")
+    modes_show.add_argument("slug")
+    modes_apply = modes_sub.add_parser("apply", help="Apply a mode to a task")
+    modes_apply.add_argument("slug")
+    modes_apply.add_argument("task", nargs="+", help="Task description")
+
+    personas = sub.add_parser("personas", help="Explore personas")
+    personas_sub = personas.add_subparsers(dest="action", required=True)
+    personas_sub.add_parser("list", help="List personas")
+    personas_show = personas_sub.add_parser("show", help="Show persona details")
+    personas_show.add_argument("slug")
+
+    compose = sub.add_parser(
+        "compose",
+        help="Compose a prompt using optional persona and mode",
+    )
+    compose.add_argument("task", nargs="+", help="Task to render inside the prompt")
+    compose.add_argument("--mode", help="Mode slug to append guidance")
+    compose.add_argument("--persona", help="Persona slug for system context")
+    compose.add_argument(
+        "--template",
+        help="Optional base template (should include '{task}')",
+    )
+    compose.add_argument("--name", help="Name for the composed prompt")
+
     args = parser.parse_args(argv)
+
     if args.cmd == "list":
         list_prompts()
     elif args.cmd == "show":
         show_prompt(args.name)
+    elif args.cmd == "modes":
+        if args.action == "list":
+            list_modes_cli()
+        elif args.action == "show":
+            show_mode_cli(args.slug)
+        elif args.action == "apply":
+            apply_mode_cli(args.slug, " ".join(args.task))
+    elif args.cmd == "personas":
+        if args.action == "list":
+            list_personas_cli()
+        elif args.action == "show":
+            show_persona_cli(args.slug)
+    elif args.cmd == "compose":
+        compose_cli(
+            " ".join(args.task),
+            mode=args.mode,
+            persona=args.persona,
+            template=args.template,
+            name=args.name,
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/teslamind/federated.py
+++ b/teslamind/federated.py
@@ -1,0 +1,10 @@
+"""Legacy entry points for federated evaluation helpers."""
+from __future__ import annotations
+
+from .advanced import FederatedEvaluation, FederatedEvaluator, ShardReport
+
+__all__ = [
+    "FederatedEvaluation",
+    "FederatedEvaluator",
+    "ShardReport",
+]

--- a/teslamind/modes/__init__.py
+++ b/teslamind/modes/__init__.py
@@ -1,12 +1,50 @@
-"""Prompt modes."""
-from .energy import energy_prompt
-from .patent import patent_prompt
-from .invention import invention_prompt
-from .visionary import visionary_prompt
-from .hyperscience import hyperscience_prompt
-from .coop import coop_prompt
+"""Convenience helpers for TeslaMind prompt modes."""
+
+from __future__ import annotations
+
+from .catalog import Mode, get_mode, list_modes
+
+
+def energy_prompt(task: str) -> str:
+    """Render ``task`` in the built-in energy mode."""
+
+    return get_mode("energy").apply(task)
+
+
+def patent_prompt(task: str) -> str:
+    """Render ``task`` in the patent tone."""
+
+    return get_mode("patent").apply(task)
+
+
+def invention_prompt(task: str) -> str:
+    """Render ``task`` in the invention ideation style."""
+
+    return get_mode("invention").apply(task)
+
+
+def visionary_prompt(task: str) -> str:
+    """Render ``task`` in the visionary storytelling style."""
+
+    return get_mode("visionary").apply(task)
+
+
+def hyperscience_prompt(task: str) -> str:
+    """Render ``task`` in the hyperscience exposition style."""
+
+    return get_mode("hyperscience").apply(task)
+
+
+def coop_prompt(task: str) -> str:
+    """Render ``task`` in the cooperative facilitation style."""
+
+    return get_mode("coop").apply(task)
+
 
 __all__ = [
+    "Mode",
+    "list_modes",
+    "get_mode",
     "energy_prompt",
     "patent_prompt",
     "invention_prompt",
@@ -14,3 +52,4 @@ __all__ = [
     "hyperscience_prompt",
     "coop_prompt",
 ]
+

--- a/teslamind/modes/catalog.py
+++ b/teslamind/modes/catalog.py
@@ -1,0 +1,152 @@
+"""Catalog of TeslaMind prompt modes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class Mode:
+    """Represents a stylistic prompt mode.
+
+    Attributes
+    ----------
+    slug:
+        Identifier used in the CLI and API. Stored in ``lowercase-with-dashes``
+        so it can be typed quickly.
+    title:
+        Human-readable title shown in documentation.
+    description:
+        Short summary of when the mode should be used.
+    voice:
+        High-level guidance for the tone the mode should adopt.
+    prefix:
+        Tagline prepended to the task when :meth:`apply` is invoked.
+    commitments:
+        Style guardrails enumerated for readers. They are rendered as a bullet
+        list when composing prompts.
+    """
+
+    slug: str
+    title: str
+    description: str
+    voice: str
+    prefix: str
+    commitments: Tuple[str, ...] = ()
+
+    def apply(self, task: str) -> str:
+        """Render the task inside the stylistic wrapper."""
+
+        normalized = " ".join(task.strip().split())
+        prompt = f"{self.prefix} {normalized}"
+        if not self.commitments:
+            return prompt
+        bullets = "\n".join(f"- {commitment}" for commitment in self.commitments)
+        return f"{prompt}\n\nStyle commitments:\n{bullets}"
+
+    def summary(self) -> str:
+        """Return a detailed, human-readable description."""
+
+        lines = [self.title, "", self.description, "", f"Voice: {self.voice}"]
+        if self.commitments:
+            lines.append("Style commitments:")
+            lines.extend(f"- {commitment}" for commitment in self.commitments)
+        return "\n".join(lines)
+
+
+_MODE_CATALOG: Dict[str, Mode] = {
+    "energy": Mode(
+        slug="energy",
+        title="Energy Mode",
+        description="Enthusiastic, action-focused output for rapid execution.",
+        voice="High-voltage direction with decisive verbs and measurable wins.",
+        prefix="[Energy Mode]",
+        commitments=(
+            "Lead with momentum and clearly defined next steps.",
+            "Quantify energetic impact and efficiency gains whenever possible.",
+            "Translate insights into execution-ready checklists.",
+        ),
+    ),
+    "patent": Mode(
+        slug="patent",
+        title="Patent Mode",
+        description="Formal technical tone suited for defensible disclosures.",
+        voice="Precise, reference-heavy prose with legal-ready clarity.",
+        prefix="[Patent Mode]",
+        commitments=(
+            "Define claims, embodiments, and novelty explicitly.",
+            "Cite supporting mechanisms and instrumentation rigorously.",
+            "Flag prior art considerations and validation evidence.",
+        ),
+    ),
+    "invention": Mode(
+        slug="invention",
+        title="Invention Mode",
+        description="Divergent brainstorming channeling Tesla's experimental flair.",
+        voice="Playful but technical ideation with rapid prototyping hooks.",
+        prefix="[Invention Mode]",
+        commitments=(
+            "Surface multiple concept variations with feasibility signals.",
+            "Propose instrumentation or experiments for each leap.",
+            "Highlight risks and possible adjacent breakthroughs.",
+        ),
+    ),
+    "visionary": Mode(
+        slug="visionary",
+        title="Visionary Mode",
+        description="Futuristic narratives that align bold visions with delivery.",
+        voice="Inspiring storytelling grounded in systems thinking.",
+        prefix="[Visionary Mode]",
+        commitments=(
+            "Connect present decisions to long-horizon outcomes.",
+            "Balance inspiration with credible technical scaffolding.",
+            "Surface societal or ecosystem-level reverberations.",
+        ),
+    ),
+    "hyperscience": Mode(
+        slug="hyperscience",
+        title="Hyperscience Mode",
+        description="Deep scientific exposition for complex phenomena.",
+        voice="Lab-grade precision with references to theory and experiment.",
+        prefix="[Hyperscience Mode]",
+        commitments=(
+            "Explain mechanisms with stepwise derivations or models.",
+            "Call out measurement apparatus, tolerances, and assumptions.",
+            "Contrast competing hypotheses and justify chosen approaches.",
+        ),
+    ),
+    "coop": Mode(
+        slug="coop",
+        title="Cooperative Mode",
+        description="Collaborative tone optimized for cross-functional teams.",
+        voice="Inclusive facilitation that keeps stakeholders aligned.",
+        prefix="[Cooperative Mode]",
+        commitments=(
+            "Invite feedback loops and surface shared objectives.",
+            "Map decision points to accountable owners and timelines.",
+            "Celebrate progress while identifying support requests.",
+        ),
+    ),
+}
+
+
+def list_modes() -> Iterable[Mode]:
+    """Return the built-in TeslaMind modes in definition order."""
+
+    return _MODE_CATALOG.values()
+
+
+def get_mode(slug: str) -> Mode:
+    """Return a single mode by its slug."""
+
+    normalized = slug.lower().replace(" ", "-")
+    try:
+        return _MODE_CATALOG[normalized]
+    except KeyError as exc:  # pragma: no cover - defensive
+        known = ", ".join(_MODE_CATALOG)
+        raise KeyError(f"Unknown mode '{slug}'. Known modes: {known}") from exc
+
+
+__all__ = ["Mode", "list_modes", "get_mode"]
+

--- a/teslamind/modes/coop.py
+++ b/teslamind/modes/coop.py
@@ -1,4 +1,9 @@
 """Collaboration mode."""
 
+from .catalog import get_mode
+
+
 def coop_prompt(task: str) -> str:
-    return f"[Cooperative Mode] {task}"
+    """Compatibility wrapper matching :func:`teslamind.modes.coop_prompt`."""
+
+    return get_mode("coop").apply(task)

--- a/teslamind/modes/energy.py
+++ b/teslamind/modes/energy.py
@@ -1,4 +1,9 @@
 """Energy mode prompts."""
 
+from .catalog import get_mode
+
+
 def energy_prompt(task: str) -> str:
-    return f"[Energy Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.energy_prompt`."""
+
+    return get_mode("energy").apply(task)

--- a/teslamind/modes/hyperscience.py
+++ b/teslamind/modes/hyperscience.py
@@ -1,4 +1,9 @@
 """Hyperscience mode."""
 
+from .catalog import get_mode
+
+
 def hyperscience_prompt(task: str) -> str:
-    return f"[Hyperscience Mode] {task}"
+    """Compatibility wrapper matching :func:`teslamind.modes.hyperscience_prompt`."""
+
+    return get_mode("hyperscience").apply(task)

--- a/teslamind/modes/invention.py
+++ b/teslamind/modes/invention.py
@@ -1,4 +1,9 @@
 """Invention mode."""
 
+from .catalog import get_mode
+
+
 def invention_prompt(task: str) -> str:
-    return f"[Invention Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.invention_prompt`."""
+
+    return get_mode("invention").apply(task)

--- a/teslamind/modes/patent.py
+++ b/teslamind/modes/patent.py
@@ -1,4 +1,9 @@
 """Patent mode."""
 
+from .catalog import get_mode
+
+
 def patent_prompt(task: str) -> str:
-    return f"[Patent Mode] {task}"
+    """Compatibility wrapper that mirrors :func:`teslamind.modes.patent_prompt`."""
+
+    return get_mode("patent").apply(task)

--- a/teslamind/modes/visionary.py
+++ b/teslamind/modes/visionary.py
@@ -1,4 +1,9 @@
 """Visionary mode."""
 
+from .catalog import get_mode
+
+
 def visionary_prompt(task: str) -> str:
-    return f"[Visionary Mode] {task}"
+    """Compatibility wrapper mirroring :func:`teslamind.modes.visionary_prompt`."""
+
+    return get_mode("visionary").apply(task)

--- a/teslamind/persona.py
+++ b/teslamind/persona.py
@@ -1,9 +1,121 @@
-"""Persona definitions."""
-from dataclasses import dataclass
+"""Persona catalog and rendering helpers."""
 
-@dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
 class Persona:
-    """A simple persona with a name and description."""
+    """Represents a Tesla-inspired persona."""
 
     name: str
     description: str
+    slug: str | None = None
+    expertise: str | None = None
+    communication_style: str | None = None
+    priorities: Tuple[str, ...] = ()
+    guardrails: Tuple[str, ...] = ()
+
+    def system_prompt(self) -> str:
+        """Return a formatted system prompt for the persona."""
+
+        lines = [f"You are the {self.name}.", self.description]
+        if self.expertise:
+            lines.append(f"Expertise: {self.expertise}.")
+        if self.communication_style:
+            lines.append(f"Communication style: {self.communication_style}.")
+        if self.priorities:
+            lines.append("Priorities:")
+            lines.extend(f"- {priority}" for priority in self.priorities)
+        if self.guardrails:
+            lines.append("Guardrails:")
+            lines.extend(f"- {guardrail}" for guardrail in self.guardrails)
+        return "\n".join(lines)
+
+    def apply(self, task: str) -> str:
+        """Render a persona-wrapped instruction block."""
+
+        prompt = self.system_prompt()
+        normalized = task.strip()
+        return f"{prompt}\n\nTask:\n{normalized}"
+
+
+_PERSONA_CATALOG: Dict[str, Persona] = {
+    "visionary-inventor": Persona(
+        slug="visionary-inventor",
+        name="Visionary Inventor",
+        description=(
+            "An ambitious, future-forward narrator who frames discoveries as "
+            "systems that can reshape industries."
+        ),
+        expertise="Moonshot ideation and multi-domain synthesis",
+        communication_style="Sweeping inspiration grounded by technical checkpoints",
+        priorities=(
+            "Propose bold yet testable prototypes.",
+            "Show the ripple effects across infrastructure and society.",
+            "Tie every idea back to Tesla's ethos of elegant efficiency.",
+        ),
+        guardrails=(
+            "Ground lofty claims with at least one concrete validation step.",
+        ),
+    ),
+    "practical-engineer": Persona(
+        slug="practical-engineer",
+        name="Practical Engineer",
+        description=(
+            "A builder who obsesses over constraints, instrumentation, and "
+            "clear acceptance criteria."
+        ),
+        expertise="Systems integration and reliability engineering",
+        communication_style="Direct execution focus with numbered procedures",
+        priorities=(
+            "Surface material limits, thermal edges, and test harnesses.",
+            "Document fallback plans and monitoring hooks.",
+            "Report progress with DM-approved sign-off cues.",
+        ),
+        guardrails=(
+            "Flag any unknowns that could block delivery before committing.",
+        ),
+    ),
+    "curious-student": Persona(
+        slug="curious-student",
+        name="Curious Student",
+        description=(
+            "An inquisitive learner eager to unpack how and why Tesla-inspired "
+            "technologies operate."
+        ),
+        expertise="Rapid learning and knowledge distillation",
+        communication_style="Question-driven exploration with analogies",
+        priorities=(
+            "Break complex ideas into layered explanations.",
+            "Surface follow-up experiments or study paths.",
+            "Invite reflective questions to confirm understanding.",
+        ),
+        guardrails=(
+            "Clarify uncertainty and cite sources before extrapolating.",
+        ),
+    ),
+}
+
+
+def list_personas() -> Iterable[Persona]:
+    """Return the built-in persona definitions."""
+
+    return _PERSONA_CATALOG.values()
+
+
+def get_persona(slug: str) -> Persona:
+    """Look up a persona by slug or case-insensitive name."""
+
+    normalized = slug.lower().replace("_", "-")
+    try:
+        return _PERSONA_CATALOG[normalized]
+    except KeyError as exc:  # pragma: no cover - defensive
+        known = ", ".join(_PERSONA_CATALOG)
+        raise KeyError(f"Unknown persona '{slug}'. Known personas: {known}") from exc
+
+
+__all__ = ["Persona", "list_personas", "get_persona"]
+

--- a/teslamind/prompt.py
+++ b/teslamind/prompt.py
@@ -1,6 +1,15 @@
 """Prompt management utilities."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
+
+from .modes import Mode, get_mode
+from .persona import Persona, get_persona
+from .templates import DEFAULT_TEMPLATE
+
 
 @dataclass
 class Prompt:
@@ -15,3 +24,73 @@ class Prompt:
 
     def save(self, path: Path) -> None:
         path.write_text(self.text)
+
+
+def _resolve_mode(mode: Mode | str | None) -> Mode | None:
+    if mode is None or isinstance(mode, Mode):
+        return mode
+    return get_mode(mode)
+
+
+def _resolve_persona(persona: Persona | str | None) -> Persona | None:
+    if persona is None or isinstance(persona, Persona):
+        return persona
+    return get_persona(persona)
+
+
+def compose_prompt(
+    task: str,
+    *,
+    mode: Mode | str | None = None,
+    persona: Persona | str | None = None,
+    template: str | None = None,
+    name: str | None = None,
+) -> Prompt:
+    """Compose a prompt that blends personas, templates, and modes.
+
+    Parameters
+    ----------
+    task:
+        The instruction to render.
+    mode:
+        Optional :class:`~teslamind.modes.catalog.Mode` (or slug) that provides
+        stylistic guardrails appended to the prompt.
+    persona:
+        Optional :class:`~teslamind.persona.Persona` (or slug) that wraps the
+        system prompt with character context.
+    template:
+        Base template. When omitted, :data:`DEFAULT_TEMPLATE` is used.
+    name:
+        Optional name for the resulting :class:`Prompt`. Defaults to the
+        persona or mode slug when available.
+    """
+
+    resolved_mode = _resolve_mode(mode)
+    resolved_persona = _resolve_persona(persona)
+    base_template = template or DEFAULT_TEMPLATE
+    normalized_task = task.strip()
+    base_prompt = base_template.format(task=normalized_task)
+
+    sections: list[str] = []
+    if resolved_persona is not None:
+        sections.append(resolved_persona.system_prompt())
+    sections.append(base_prompt)
+    if resolved_mode is not None:
+        sections.append(resolved_mode.apply(normalized_task))
+
+    prompt_name_candidates: Iterable[str | None] = (
+        name,
+        getattr(resolved_persona, "slug", None),
+        getattr(resolved_mode, "slug", None),
+    )
+    for candidate in prompt_name_candidates:
+        if candidate:
+            prompt_name = candidate.replace(" ", "-")
+            break
+    else:  # pragma: no cover - fallback when all candidates are empty
+        prompt_name = "composed"
+
+    return Prompt(name=prompt_name, text="\n\n".join(sections))
+
+
+__all__ = ["Prompt", "compose_prompt"]

--- a/teslamind/refinement.py
+++ b/teslamind/refinement.py
@@ -1,0 +1,11 @@
+"""Legacy entry points for prompt refinement helpers."""
+from __future__ import annotations
+
+from .advanced import RefineFunction, RefineOutput, RefinementStep, SelfLoopingPromptRefiner
+
+__all__ = [
+    "RefineFunction",
+    "RefineOutput",
+    "RefinementStep",
+    "SelfLoopingPromptRefiner",
+]

--- a/teslamind/rlhf.py
+++ b/teslamind/rlhf.py
@@ -1,0 +1,10 @@
+"""Legacy entry points for RLHF helpers."""
+from __future__ import annotations
+
+from .advanced import RLHFTrainer, RLHFTrainingResult, RewardRecord
+
+__all__ = [
+    "RLHFTrainer",
+    "RLHFTrainingResult",
+    "RewardRecord",
+]

--- a/teslamind/safety.py
+++ b/teslamind/safety.py
@@ -1,0 +1,10 @@
+"""Legacy entry points for clinical safety helpers."""
+from __future__ import annotations
+
+from .advanced import ClinicalSafetyFilter, SafetyReport, SafetyViolation
+
+__all__ = [
+    "ClinicalSafetyFilter",
+    "SafetyReport",
+    "SafetyViolation",
+]

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -1,0 +1,68 @@
+import pytest
+
+from teslamind.advanced import (
+    ClinicalSafetyFilter,
+    FederatedEvaluator,
+    RLHFTrainer,
+    SelfLoopingPromptRefiner,
+)
+
+
+def test_self_looping_prompt_refiner_tracks_history():
+    def refine(prompt: str):
+        return prompt + "!", {"score": len(prompt)}
+
+    refiner = SelfLoopingPromptRefiner(refine, max_iterations=5, score_threshold=5)
+    final_prompt, history = refiner.refine("go", return_history=True)
+
+    assert final_prompt.endswith("!")
+    assert history[-1].score is not None
+    assert history[-1].score >= 5
+    assert len(history) <= 5
+
+
+def test_federated_evaluator_averages_numeric_metrics():
+    def evaluator(prompts):
+        return {"avg_length": sum(len(p) for p in prompts) / len(prompts)}
+
+    evaluator_instance = FederatedEvaluator(evaluator)
+    result = evaluator_instance.evaluate({
+        "lab": ["coil", "transformer"],
+        "field": ["resonance"],
+    })
+
+    assert result.aggregate["avg_length"] == pytest.approx(
+        (
+            (len("coil") + len("transformer")) / 2
+            + len("resonance")
+        )
+        / 2
+    )
+    assert len(result.reports) == 2
+
+
+def test_rlhf_trainer_filters_prompts_by_reward():
+    trainer = RLHFTrainer(lambda prompt: 1.0 if "⚡" in prompt else 0.0, reward_threshold=0.5)
+    prompts = ["coil", "coil ⚡"]
+
+    result = trainer.train(prompts)
+
+    assert result.accepted == ["coil ⚡"]
+    assert result.rejected == ["coil"]
+    assert [record.prompt for record in result.history] == prompts
+
+
+def test_clinical_safety_filter_masks_terms():
+    filter_ = ClinicalSafetyFilter(["diagnosis"], mask=True, mask_char="*")
+    report = filter_.scan("Initial diagnosis pending")
+
+    assert not report.is_clean
+    assert report.sanitized_text.startswith("Initial ")
+    assert "******" in report.sanitized_text
+
+
+def test_clinical_safety_filter_can_raise_on_violation():
+    filter_ = ClinicalSafetyFilter(["diagnosis"], raise_on_violation=True)
+
+    with pytest.raises(ValueError):
+        filter_.scan("Initial diagnosis pending")

--- a/tests/test_advanced_compat.py
+++ b/tests/test_advanced_compat.py
@@ -1,0 +1,27 @@
+from teslamind import (
+    ClinicalSafetyFilter,
+    FederatedEvaluator,
+    RLHFTrainer,
+    SelfLoopingPromptRefiner,
+)
+from teslamind.federated import FederatedEvaluation, ShardReport
+from teslamind.refinement import RefineFunction, RefineOutput, RefinementStep
+from teslamind.rlhf import RLHFTrainingResult, RewardRecord
+from teslamind.safety import SafetyReport, SafetyViolation
+
+
+def test_legacy_modules_reexport_helpers():
+    assert RefineFunction
+    assert RefineOutput
+    assert RefinementStep
+    assert isinstance(ShardReport(shard="lab", prompts=[], metrics={}), ShardReport)
+    assert isinstance(FederatedEvaluation(reports=[], aggregate={}), FederatedEvaluation)
+    assert isinstance(RLHFTrainingResult(accepted=[], rejected=[], history=[]), RLHFTrainingResult)
+    assert isinstance(RewardRecord(prompt="", reward=0.0), RewardRecord)
+    assert isinstance(SafetyViolation(term="x", start=0, end=1), SafetyViolation)
+    assert isinstance(SafetyReport(original_text="", sanitized_text="", violations=[]), SafetyReport)
+    # Access top-level exports to ensure __all__ wiring stays intact.
+    assert ClinicalSafetyFilter
+    assert FederatedEvaluator
+    assert RLHFTrainer
+    assert SelfLoopingPromptRefiner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,49 @@ from teslamind import cli
 def test_list_prompts(capsys):
     cli.list_prompts()
     captured = capsys.readouterr()
-    assert "prompt1" in captured.out
-    assert "prompt2" in captured.out
-    assert "prompt3" in captured.out
-    assert "prompt4" in captured.out
+    lines = [line.strip() for line in captured.out.splitlines() if line.strip()]
+    assert lines[:4] == ["dev_prompt_aether_engineer", "dev_prompt_dynamo_core", "dev_prompt_luminal_cartographer", "dev_prompt_magnetic_foundry"]
+    assert "prompt1" in lines
+
+
+def test_modes_cli(capsys):
+    cli.list_modes_cli()
+    listing = capsys.readouterr().out
+    assert "energy" in listing
+    assert "Visionary Mode" in listing
+
+    cli.show_mode_cli("energy")
+    show_output = capsys.readouterr().out
+    assert "Energy Mode" in show_output
+    assert "Style commitments" in show_output
+
+    cli.apply_mode_cli("energy", "Design a resilient motor")
+    applied = capsys.readouterr().out
+    assert "[Energy Mode] Design a resilient motor" in applied
+    assert "Translate insights" in applied
+
+
+def test_persona_cli(capsys):
+    cli.list_personas_cli()
+    listing = capsys.readouterr().out
+    assert "visionary-inventor" in listing
+    assert "Practical Engineer" in listing
+
+    cli.show_persona_cli("practical-engineer")
+    detail = capsys.readouterr().out
+    assert "You are the Practical Engineer" in detail
+    assert "Systems integration" in detail
+
+
+def test_compose_cli(capsys):
+    cli.compose_cli(
+        "Prototype a wireless energy bridge",
+        mode="visionary",
+        persona="visionary-inventor",
+        template="You are smarter than Nikola Tesla in 2024. {task}",
+        name=None,
+    )
+    output = capsys.readouterr().out
+    assert "You are the Visionary Inventor" in output
+    assert "Prototype a wireless energy bridge" in output
+    assert "[Visionary Mode] Prototype a wireless energy bridge" in output

--- a/tests/test_modes_personas.py
+++ b/tests/test_modes_personas.py
@@ -1,0 +1,23 @@
+from teslamind.modes import get_mode, list_modes
+from teslamind.persona import get_persona, list_personas
+
+
+def test_mode_catalog_contains_energy():
+    slugs = [mode.slug for mode in list_modes()]
+    assert "energy" in slugs
+    mode = get_mode("energy")
+    assert "Energy Mode" in mode.summary()
+    rendered = mode.apply("Stabilize wireless transfer")
+    assert rendered.startswith("[Energy Mode] Stabilize wireless transfer")
+    assert "Style commitments" in rendered
+
+
+def test_persona_catalog_contains_curiosity():
+    slugs = [persona.slug for persona in list_personas()]
+    assert "curious-student" in slugs
+    persona = get_persona("curious-student")
+    system_prompt = persona.system_prompt()
+    assert "Curious Student" in system_prompt
+    rendered = persona.apply("Explain resonance")
+    assert "Task:" in rendered
+    assert "Explain resonance" in rendered

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,8 @@
 from pathlib import Path
-from teslamind.prompt import Prompt
+
+import pytest
+
+from teslamind.prompt import Prompt, compose_prompt
 
 
 def test_from_file(tmp_path: Path):
@@ -14,3 +17,32 @@ def test_save(tmp_path: Path):
     out = tmp_path / "x.txt"
     p.save(out)
     assert out.read_text() == "data"
+
+
+def test_compose_prompt_with_mode_and_persona():
+    prompt = compose_prompt(
+        "Draft the inspection plan",
+        persona="practical-engineer",
+        mode="energy",
+    )
+    assert "You are the Practical Engineer" in prompt.text
+    assert "[Energy Mode] Draft the inspection plan" in prompt.text
+    assert prompt.name == "practical-engineer"
+
+
+def test_compose_prompt_with_custom_template_and_name():
+    template = "Operate with relentless clarity: {task}."
+    prompt = compose_prompt(
+        "Diagnose oscillations",
+        mode="hyperscience",
+        template=template,
+        name="custom",
+    )
+    assert "Operate with relentless clarity: Diagnose oscillations." in prompt.text
+    assert "[Hyperscience Mode] Diagnose oscillations" in prompt.text
+    assert prompt.name == "custom"
+
+
+def test_compose_prompt_invalid_mode(monkeypatch):
+    with pytest.raises(KeyError):
+        compose_prompt("Task", mode="unknown-mode")


### PR DESCRIPTION
## Summary
- reintroduce the legacy `teslamind.refinement`, `teslamind.federated`, `teslamind.rlhf`, and `teslamind.safety` modules as shims over the consolidated advanced helpers
- expand the package exports, README, and docs to explain the compatibility layer
- add regression coverage to ensure the legacy import paths continue to resolve the new helper classes and dataclasses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89b6524388320b00ad208f04c45e2